### PR TITLE
IRR - Multigraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ name = "contact_plans"
 path = "examples/contact_plans/contact_plans.rs"
 
 [[example]]
+name = "inter-regional_routing"
+path = "examples/inter-regional_routing/inter-regional_routing.rs"
+
+[[example]]
 name = "0-ion-tvgutil-parsing"
 path = "exercises/0-ion-tvgutil-parsing/0-ion-tvgutil-parsing.rs"
 

--- a/examples/bundle_processing/bundle_processing.rs
+++ b/examples/bundle_processing/bundle_processing.rs
@@ -5,7 +5,7 @@ use a_sabr::errors::ASABRError;
 use a_sabr::node_manager::NodeManager;
 use a_sabr::node_manager::none::NoManagement;
 use a_sabr::parsing::coerce_nm;
-use a_sabr::parsing::{DispatchParser, Lexer, Parser, ParsingState};
+use a_sabr::parsing::{DispatchParser, Lexer, Parser};
 use a_sabr::parsing::{NodeMarkerMap, StaticMarkerMap};
 use a_sabr::pathfinding::Pathfinding;
 use a_sabr::pathfinding::hybrid_parenting::HybridParentingPath;
@@ -73,17 +73,10 @@ impl DispatchParser<Compressing> for Compressing {}
 
 /// The parser reads a maximum priority
 impl Parser<Compressing> for Compressing {
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<Compressing> {
-        let max_priority_state = <Priority as Token<Priority>>::parse(lexer);
-        match max_priority_state {
-            ParsingState::Finished(value) => ParsingState::Finished(Compressing {
-                max_priority: value,
-            }),
-            ParsingState::Error(msg) => ParsingState::Error(msg),
-            ParsingState::EOF => {
-                ParsingState::Error(format!("Parsing failed ({})", lexer.get_current_position()))
-            }
-        }
+    fn parse(lexer: &mut dyn Lexer) -> Result<Compressing, ASABRError> {
+        Ok(Compressing {
+            max_priority: Priority::parse(lexer)?,
+        })
     }
 }
 

--- a/examples/contact_plans/contact_plans.rs
+++ b/examples/contact_plans/contact_plans.rs
@@ -24,7 +24,7 @@ fn main() {
     .unwrap();
     println!(
         "ION CP parsed, found {} nodes (no management) & {} contacts (segmentation)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
     // ION, with EVL
@@ -33,7 +33,7 @@ fn main() {
             .unwrap();
     println!(
         "ION CP parsed, found {} nodes (no management) & {} contacts (EVL)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 
@@ -43,7 +43,7 @@ fn main() {
             .unwrap();
     println!(
         "ION CP parsed, found {} nodes (no management) & {} contacts (EVL with priorities)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 
@@ -54,7 +54,7 @@ fn main() {
     .unwrap();
     println!(
         "Tvg-util CP parsed, found {} nodes (no management) & {} contacts (segmentation)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 
@@ -65,7 +65,7 @@ fn main() {
     .unwrap();
     println!(
         "Tvg-util CP parsed, found {} nodes (no management) & {} contacts (EVL)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 
@@ -76,7 +76,7 @@ fn main() {
     .unwrap();
     println!(
         "Tvg-util CP parsed, found {} nodes (no management) & {} contacts (queue-delay with priorities)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 
@@ -85,7 +85,7 @@ fn main() {
         ASABRContactPlan::parse::<NoManagement, EVLManager>(&mut mylexer, None, None).unwrap();
     println!(
         "A-SABR CP parsed (statically for nodes & contacts), found {} nodes (no management) & {} contacts (EVL)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 
@@ -96,7 +96,7 @@ fn main() {
         ASABRContactPlan::parse::<NoManagement, QDManager>(&mut mylexer, None, None).unwrap();
     println!(
         "A-SABR CP parsed (statically for nodes & contacts), found {} nodes (no management) & {} contacts (queue-delay)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 
@@ -120,7 +120,7 @@ fn main() {
     .unwrap();
     println!(
         "A-SABR CP parsed (statically for nodes, dynamically for contacts), found {} nodes (no management) & {} contacts (of various types)",
-        contact_plan.nodes.len(),
+        contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
 }

--- a/examples/inter-regional_routing/README.md
+++ b/examples/inter-regional_routing/README.md
@@ -1,0 +1,35 @@
+## Inter-regional routing
+
+### Run the example
+
+This example does not require any features yet, but we may add a `vnode_routing` (or similar) feature in the future:
+
+```bash
+cargo run --example inter-regional_routing
+```
+
+### Motivation
+
+Network authorities administer nodes in separate 'regions' (this term lacks a reference). This leads to concerns about inter-regional routing: one authority may want to allows other authorities to cross its regions without exposing extensive informations internal to the regions, such as nodes, node managers, contacts, etc.
+This exposes the need to abstract regions as 'black boxes', as well as the need for anycast routing, to the closest contact to a given region.
+Multiple approaches to the problem of inter-regional routing have surfaced (BIBE, node passageways, contact passageways). We focus on node passageways and contact passageways.
+
+We wish to implement an abstraction over both.
+In terms of research, this could lead to results such as finding one approach to be a more general case, or inversely a degenerate case of the other.
+In turn we may find a common model in which both cases are degenerate cases of the model.
+
+We also use this abstraction to compare both approaches on various criteria.
+
+### Principles
+
+A-SABR introduces contact plan elements to label nodes, in order to create "groups" or "virtual nodes" (`vnode` in the contact plan) for anycast routing; as well as "external nodes" (`enode` in the contact plan) which can only be routed to using anycast, and thus must be labelled with at least one vnode.
+These elements are only available in the A-SABR contact plan format.
+
+A node (`node` in the contact plan) is called an "internal node" or "inode" to differentiate it from an enode.
+
+Contacts still only point to real nodes (i.e. inodes or enodes), they cannot point to vnodes as they are only labels, not real nodes.
+
+During multigraph creation, the Sender/Receiver abstraction over the graph is extended with new vertices for each virtual node, whose set of contacts is the union of the contacts of the real nodes that the vnode labels.
+
+External nodes enable efficient representation of nodes that hold few information or little interest for unicast routing, e.g. nodes of a separate region, as they are not added as Senders or Receivers in the graph. They only exist as contact Tx/Rx nodes.
+External nodes are expected to most often have a `NoManager` manager.

--- a/examples/inter-regional_routing/asabr_format_dynamic.cp
+++ b/examples/inter-regional_routing/asabr_format_dynamic.cp
@@ -1,0 +1,30 @@
+
+# Node entry with no management: node <id> <name>
+node 0 node1
+node 1 node2
+node 2 node3
+node 3 node4
+node 4 node5
+node 5 node6
+
+vnode 6 node7 [ 0 1 5 ]
+
+# Dynamic parsing for contacts a marker should appear before the manager tokens:
+# contact <from> <to> <start> <end> <marker> ...
+contact 0 1 60 7260 eto 10000 10
+contact 1 2 60 7260 evl 15000 15
+contact 2 3 60 7260 evl 20000 20
+contact 3 4 60 7260 qd 25000 25
+contact 4 5 60 7260 qd 30000 30
+contact 4 0 60 7260 qd 30000 30
+
+# A segmented contact after the marker, the parser expects a sequence of delay/rate intervals:
+# delay <start> <end> <delay>
+# rate <start> <end> <rate>
+contact 0 5 60 7260 seg rate 60 3660 10000 rate 3660 7260 15000 delay 60 7260 12
+
+# A-SABR format does not care of whitespaces, including new lines:
+contact 1 4 60 7260 seg
+delay 60 3660 10
+delay 3660 7260 15
+rate 60 7260 10000

--- a/examples/inter-regional_routing/inter-regional_routing.rs
+++ b/examples/inter-regional_routing/inter-regional_routing.rs
@@ -1,0 +1,76 @@
+use std::{cell::RefCell, rc::Rc};
+
+use a_sabr::{
+    bundle::Bundle,
+    contact_manager::{
+        ContactManager,
+        legacy::{eto::ETOManager, evl::EVLManager, qd::QDManager},
+        segmentation::seg::SegmentationManager,
+    },
+    contact_plan::{asabr_file_lexer::FileLexer, from_asabr_lexer::ASABRContactPlan},
+    node_manager::none::NoManagement,
+    parsing::{ContactMarkerMap, coerce_cm},
+    route_storage::cache::TreeCache,
+    routing::{Router, aliases::SpsnHybridParenting},
+    utils::pretty_print,
+};
+
+fn main() {
+    let mut mylexer =
+        FileLexer::new("examples/inter-regional_routing/asabr_format_dynamic.cp").unwrap();
+    // All nodes will have the same management approach (NoManagement) but the contacts may be of various types
+    // We provide a map with markers that will allow the parser to create the correct contacts types thanks to
+    // the markers provides in the contact plan
+    let mut contact_dispatch: ContactMarkerMap = ContactMarkerMap::new();
+    contact_dispatch.add("eto", coerce_cm::<ETOManager>);
+    contact_dispatch.add("qd", coerce_cm::<QDManager>);
+    contact_dispatch.add("evl", coerce_cm::<EVLManager>);
+    contact_dispatch.add("seg", coerce_cm::<SegmentationManager>);
+
+    // The manager type should be Box<dyn ContactManager>> (heap allocated, dynamically dispatched)
+    // Replace None with a dispatching map for the contact_marker_map argument
+    let contact_plan = ASABRContactPlan::parse::<NoManagement, Box<dyn ContactManager>>(
+        &mut mylexer,
+        None,
+        Some(&contact_dispatch),
+    )
+    .unwrap();
+    println!(
+        "A-SABR CP parsed (statically for nodes, dynamically for contacts), found {} nodes (no management) & {} contacts (of various types)",
+        contact_plan.vertices.len(),
+        contact_plan.contacts.len()
+    );
+
+    println!("Virtual nodes map:");
+    dbg!(&contact_plan.vnode_map);
+
+    // We create a storage for the Paths
+    let table = Rc::new(RefCell::new(TreeCache::new(true, false, 10)));
+    // We initialize the routing algorithm with the storage and the contacts/nodes created thanks to the parser
+    let mut spsn = SpsnHybridParenting::<NoManagement, Box<dyn ContactManager>>::new(
+        contact_plan,
+        table,
+        false,
+    )
+    .unwrap();
+
+    // We will route a bundle
+    let b = Bundle {
+        source: 0,
+        destinations: vec![4],
+        priority: 0,
+        size: 1.0,
+        expiration: 10000.0,
+    };
+
+    // We schedule the bundle (resource updates were conducted)
+    let out = spsn.route(0, &b, 0.0, &Vec::new());
+
+    if let Ok(Some(out)) = out {
+        for (_contact, dest_routes) in out.first_hops.values() {
+            for route_rc in dest_routes {
+                pretty_print(route_rc.clone());
+            }
+        }
+    }
+}

--- a/examples/satellite_constellation/satellite_constellation.rs
+++ b/examples/satellite_constellation/satellite_constellation.rs
@@ -6,7 +6,7 @@ use a_sabr::node_manager::NodeManager;
 use a_sabr::node_manager::none::NoManagement;
 use a_sabr::parsing::NodeMarkerMap;
 use a_sabr::parsing::coerce_nm;
-use a_sabr::parsing::{DispatchParser, Lexer, Parser, ParsingState, StaticMarkerMap};
+use a_sabr::parsing::{DispatchParser, Lexer, Parser, StaticMarkerMap};
 use a_sabr::pathfinding::Pathfinding;
 use a_sabr::pathfinding::hybrid_parenting::HybridParentingPath;
 use a_sabr::types::Date;
@@ -62,19 +62,11 @@ impl NodeManager for NoRetention {
 impl DispatchParser<NoRetention> for NoRetention {}
 
 impl Parser<NoRetention> for NoRetention {
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<NoRetention> {
+    fn parse(lexer: &mut dyn Lexer) -> Result<NoRetention, ASABRError> {
         // read the next token as a Duration (alias for f64)
-        let max = <Duration as Token<Duration>>::parse(lexer);
-        // treat success/error cases
-        match max {
-            ParsingState::Finished(value) => ParsingState::Finished(NoRetention {
-                max_proc_time: value,
-            }),
-            ParsingState::Error(msg) => ParsingState::Error(msg),
-            ParsingState::EOF => {
-                ParsingState::Error(format!("Parsing failed ({})", lexer.get_current_position()))
-            }
-        }
+        Ok(NoRetention {
+            max_proc_time: Duration::parse(lexer)?,
+        })
     }
 }
 

--- a/exercises/0-ion-tvgutil-parsing/README.md
+++ b/exercises/0-ion-tvgutil-parsing/README.md
@@ -69,8 +69,8 @@ The `Node` structure is templated with some type `NM`. `NM` must implement the `
 
 ```rust
 pub struct ContactInfo {
-    pub tx_node: NodeID,
-    pub rx_node: NodeID,
+    pub tx_node_id: NodeID,
+    pub rx_node_id: NodeID,
     pub start: Date,
     pub end: Date,
 }

--- a/exercises/1-asabr-static-parsing/README.md
+++ b/exercises/1-asabr-static-parsing/README.md
@@ -13,8 +13,8 @@ This requires contact plan format extensions with a registration system that doe
 ```rust
 
 pub struct ContactInfo {
-    pub tx_node: NodeID,
-    pub rx_node: NodeID,
+    pub tx_node_id: NodeID,
+    pub rx_node_id: NodeID,
     pub start: Date,
     pub end: Date,
 }

--- a/exercises/2-contact-segmentation/2-contact-segmentation.rs
+++ b/exercises/2-contact-segmentation/2-contact-segmentation.rs
@@ -32,5 +32,8 @@ fn main() {
         }
     };
 
-    println!("CP:\n{:#?}", (&contact_plan.nodes, &contact_plan.contacts));
+    println!(
+        "CP:\n{:#?}",
+        (&contact_plan.vertices, &contact_plan.contacts)
+    );
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -4,8 +4,10 @@ use crate::parsing::{Lexer, Parser, ParsingState};
 #[cfg(feature = "contact_work_area")]
 use crate::route_stage::SharedRouteStage;
 use crate::types::{Date, NodeID, Token};
+use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
+use std::rc::Rc;
 
 /// Represents basic information about a contact between two nodes.
 #[derive(Clone, Copy)]
@@ -77,6 +79,8 @@ pub struct Contact<NM: NodeManager, CM: ContactManager> {
     #[doc(hidden)]
     _phantom_nm: PhantomData<NM>,
 }
+
+pub type SharedContact<NM, CM> = Rc<RefCell<Contact<NM, CM>>>;
 
 impl<NM: NodeManager, CM: ContactManager> Contact<NM, CM> {
     /// Creates a new `Contact` instance if the contact information and manager are valid.

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -128,6 +128,14 @@ impl<NM: NodeManager, CM: ContactManager> Contact<NM, CM> {
     pub fn get_rx_node_id(&self) -> NodeID {
         self.info.rx_node_id
     }
+
+    /// Compare two contacts by start time.
+    pub fn cmp_by_start(&self, other: &Self) -> Ordering {
+        self.info
+            .start
+            .partial_cmp(&other.info.start)
+            .unwrap_or(Ordering::Equal)
+    }
 }
 
 impl<NM: NodeManager, CM: ContactManager> Ord for Contact<NM, CM> {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,6 +1,7 @@
 use crate::contact_manager::ContactManager;
+use crate::errors::ASABRError;
 use crate::node_manager::NodeManager;
-use crate::parsing::{Lexer, Parser, ParsingState};
+use crate::parsing::{Lexer, Parser};
 #[cfg(feature = "contact_work_area")]
 use crate::route_stage::SharedRouteStage;
 use crate::types::{Date, NodeID, Token};
@@ -186,56 +187,16 @@ impl Parser<ContactInfo> for ContactInfo {
     ///
     /// # Returns
     ///
-    /// * `ParsingState<ContactInfo>` - The parsing state indicating success or failure.
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<ContactInfo> {
-        let tx_node_state = NodeID::parse(lexer);
-        let tx_node_id: NodeID = match tx_node_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+    /// * `Result<LexerOutput<ContactInfo>, ASABRError>` - The successful parsing state or an error.
+    fn parse(lexer: &mut dyn Lexer) -> Result<ContactInfo, ASABRError> {
+        let tx_node_id: NodeID = NodeID::parse(lexer)?;
 
-        let rx_node_state = NodeID::parse(lexer);
-        let rx_node_id: NodeID = match rx_node_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+        let rx_node_id: NodeID = NodeID::parse(lexer)?;
 
-        let start_state = Date::parse(lexer);
-        let start: Date = match start_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+        let start: Date = Date::parse(lexer)?;
 
-        let end_state = Date::parse(lexer);
-        let end: Date = match end_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+        let end: Date = Date::parse(lexer)?;
 
-        ParsingState::Finished(ContactInfo::new(tx_node_id, rx_node_id, start, end))
+        Ok(ContactInfo::new(tx_node_id, rx_node_id, start, end))
     }
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -12,9 +12,9 @@ use std::marker::PhantomData;
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ContactInfo {
     ///The ID of the transmitting node.
-    pub tx_node: NodeID,
+    pub tx_node_id: NodeID,
     /// The ID of the receiving node.
-    pub rx_node: NodeID,
+    pub rx_node_id: NodeID,
     /// The start time of the contact.
     pub start: Date,
     /// The end time of the contact.
@@ -26,18 +26,18 @@ impl ContactInfo {
     ///
     /// # Parameters
     ///
-    /// * `tx_node` - The ID of the transmitting node.
-    /// * `rx_node` - The ID of the receiving node.
+    /// * `tx_node_id` - The ID of the transmitting node.
+    /// * `rx_node_id` - The ID of the receiving node.
     /// * `start` - The start time of the contact.
     /// * `end` - The end time of the contact.
     ///
     /// # Returns
     ///
     /// * `Self` - A new instance of `ContactInfo`.
-    pub fn new(tx_node: NodeID, rx_node: NodeID, start: Date, end: Date) -> Self {
+    pub fn new(tx_node_id: NodeID, rx_node_id: NodeID, start: Date, end: Date) -> Self {
         Self {
-            tx_node,
-            rx_node,
+            tx_node_id,
+            rx_node_id,
             start,
             end,
         }
@@ -111,8 +111,8 @@ impl<NM: NodeManager, CM: ContactManager> Contact<NM, CM> {
     ///
     /// * `NodeID` - The ID of the transmitting node.
     #[inline(always)]
-    pub fn get_tx_node(&self) -> NodeID {
-        self.info.tx_node
+    pub fn get_tx_node_id(&self) -> NodeID {
+        self.info.tx_node_id
     }
 
     /// Retrieves the receiving node's ID.
@@ -121,23 +121,23 @@ impl<NM: NodeManager, CM: ContactManager> Contact<NM, CM> {
     ///
     /// * `NodeID` - The ID of the receiving node.
     #[inline(always)]
-    pub fn get_rx_node(&self) -> NodeID {
-        self.info.rx_node
+    pub fn get_rx_node_id(&self) -> NodeID {
+        self.info.rx_node_id
     }
 }
 
 impl<NM: NodeManager, CM: ContactManager> Ord for Contact<NM, CM> {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.info.tx_node > other.info.tx_node {
+        if self.info.tx_node_id > other.info.tx_node_id {
             return Ordering::Greater;
         }
-        if self.info.tx_node < other.info.tx_node {
+        if self.info.tx_node_id < other.info.tx_node_id {
             return Ordering::Less;
         }
-        if self.info.rx_node > other.info.rx_node {
+        if self.info.rx_node_id > other.info.rx_node_id {
             return Ordering::Greater;
         }
-        if self.info.rx_node < other.info.rx_node {
+        if self.info.rx_node_id < other.info.rx_node_id {
             return Ordering::Less;
         }
         if self.info.start > other.info.start {
@@ -158,8 +158,8 @@ impl<NM: NodeManager, CM: ContactManager> PartialOrd for Contact<NM, CM> {
 
 impl<NM: NodeManager, CM: ContactManager> PartialEq for Contact<NM, CM> {
     fn eq(&self, other: &Self) -> bool {
-        self.info.tx_node == other.info.tx_node
-            && self.info.rx_node == other.info.rx_node
+        self.info.tx_node_id == other.info.tx_node_id
+            && self.info.rx_node_id == other.info.rx_node_id
             && self.info.start == other.info.start
     }
 }
@@ -177,7 +177,7 @@ impl Parser<ContactInfo> for ContactInfo {
     /// * `ParsingState<ContactInfo>` - The parsing state indicating success or failure.
     fn parse(lexer: &mut dyn Lexer) -> ParsingState<ContactInfo> {
         let tx_node_state = NodeID::parse(lexer);
-        let tx_node: NodeID = match tx_node_state {
+        let tx_node_id: NodeID = match tx_node_state {
             ParsingState::Finished(value) => value,
             ParsingState::Error(msg) => return ParsingState::Error(msg),
             ParsingState::EOF => {
@@ -189,7 +189,7 @@ impl Parser<ContactInfo> for ContactInfo {
         };
 
         let rx_node_state = NodeID::parse(lexer);
-        let rx_node: NodeID = match rx_node_state {
+        let rx_node_id: NodeID = match rx_node_state {
             ParsingState::Finished(value) => value,
             ParsingState::Error(msg) => return ParsingState::Error(msg),
             ParsingState::EOF => {
@@ -224,6 +224,6 @@ impl Parser<ContactInfo> for ContactInfo {
             }
         };
 
-        ParsingState::Finished(ContactInfo::new(tx_node, rx_node, start, end))
+        ParsingState::Finished(ContactInfo::new(tx_node_id, rx_node_id, start, end))
     }
 }

--- a/src/contact_manager/legacy/mod.rs
+++ b/src/contact_manager/legacy/mod.rs
@@ -66,8 +66,8 @@ macro_rules! generate_struct_management {
                return self.original_volume;
             }
             #[inline(always)]
-            fn build_parsing_output(rate: $crate::types::DataRate, delay: $crate::types::Duration, _lexer: &mut dyn $crate::parsing::Lexer) -> $crate::parsing::ParsingState<Self>{
-                return $crate::parsing::ParsingState::Finished($manager_name::new(rate, delay));
+            fn build_parsing_output(rate: $crate::types::DataRate, delay: $crate::types::Duration, _lexer: &mut dyn $crate::parsing::Lexer) -> Result<Self, $crate::errors::ASABRError>{
+                return Ok($manager_name::new(rate, delay));
             }
         }
     };
@@ -127,8 +127,8 @@ macro_rules! generate_struct_management {
                return self.original_volume;
             }
             #[inline(always)]
-            fn build_parsing_output(rate: $crate::types::DataRate, delay: $crate::types::Duration, _lexer: &mut dyn $crate::parsing::Lexer) -> $crate::parsing::ParsingState<Self>{
-                return $crate::parsing::ParsingState::Finished($manager_name::new(rate, delay));
+            fn build_parsing_output(rate: $crate::types::DataRate, delay: $crate::types::Duration, _lexer: &mut dyn $crate::parsing::Lexer) -> Result<Self, $crate::errors::ASABRError>{
+                return Ok($manager_name::new(rate, delay));
             }
         }
     };
@@ -193,24 +193,15 @@ macro_rules! generate_struct_management {
                return self.budgets[bundle.priority as usize];
             }
             #[inline(always)]
-            fn build_parsing_output(rate: $crate::types::DataRate, delay: $crate::types::Duration, lexer: &mut dyn $crate::parsing::Lexer) -> $crate::parsing::ParsingState<Self>{
+            fn build_parsing_output(rate: $crate::types::DataRate, delay: $crate::types::Duration, lexer: &mut dyn $crate::parsing::Lexer) -> Result<Self, $crate::errors::ASABRError>{
                 let mut budgets = [0.0; 3];
                 for i in 0..$prio_count {
 
-                    let budget_state = <$crate::types::Volume as $crate::types::Token<$crate::types::Volume>>::parse(lexer);
-                    match budget_state {
-                        $crate::parsing::ParsingState::Finished(value) => budgets[i] = value,
-                        $crate::parsing::ParsingState::Error(msg) => return $crate::parsing::ParsingState::Error(msg),
-                        $crate::parsing::ParsingState::EOF => {
-                            return $crate::parsing::ParsingState::Error(format!(
-                                "Parsing failed ({})",
-                                lexer.get_current_position()
-                            ))
-                        }
-                    }
+                    let budget = <$crate::types::Volume as $crate::types::Token<$crate::types::Volume>>::parse(lexer)?;
+                    budgets[i] = budget;
                 }
 
-                return $crate::parsing::ParsingState::Finished($manager_name::new(rate, delay, budgets));
+                return Ok($manager_name::new(rate, delay, budgets));
             }
         }
     };
@@ -384,36 +375,13 @@ macro_rules! generate_prio_volume_manager {
             ///
             /// # Returns
             ///
-            /// Returns a `ParsingState` indicating whether parsing was successful (`Finished`) or encountered an error (`Error`).
+            /// Returns a `Result<LexerOutput<T>, ASABRError>` indicating whether parsing was successful
+            /// (`Finished`) or encountered an error.
             fn parse(
                 lexer: &mut dyn $crate::parsing::Lexer,
-            ) -> $crate::parsing::ParsingState<$manager_name> {
-                let delay: $crate::types::Duration;
-                let rate: $crate::types::DataRate;
-
-                let rate_state = <$crate::types::DataRate as $crate::types::Token<$crate::types::DataRate>>::parse(lexer);
-                match rate_state {
-                    $crate::parsing::ParsingState::Finished(value) => rate = value,
-                    $crate::parsing::ParsingState::Error(msg) => return $crate::parsing::ParsingState::Error(msg),
-                    $crate::parsing::ParsingState::EOF => {
-                        return $crate::parsing::ParsingState::Error(format!(
-                            "Parsing failed ({})",
-                            lexer.get_current_position()
-                        ))
-                    }
-                }
-
-                let delay_state = <$crate::types::Duration as $crate::types::Token<$crate::types::Duration>>::parse(lexer);
-                match delay_state {
-                    $crate::parsing::ParsingState::Finished(value) => delay = value,
-                    $crate::parsing::ParsingState::Error(msg) => return $crate::parsing::ParsingState::Error(msg),
-                    $crate::parsing::ParsingState::EOF => {
-                        return $crate::parsing::ParsingState::Error(format!(
-                            "Parsing failed ({})",
-                            lexer.get_current_position()
-                        ))
-                    }
-                }
+            ) -> Result<$manager_name, $crate::errors::ASABRError> {
+                let rate = <$crate::types::DataRate as $crate::types::Token<$crate::types::DataRate>>::parse(lexer)?;
+                let delay = <$crate::types::Duration as $crate::types::Token<$crate::types::Duration>>::parse(lexer)?;
                 return Self::build_parsing_output(rate, delay, lexer);
             }
         }

--- a/src/contact_manager/mod.rs
+++ b/src/contact_manager/mod.rs
@@ -6,7 +6,7 @@ pub mod legacy;
 pub mod segmentation;
 
 /// Data structure representing the transmission (tx) start, end, and related timing information.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ContactManagerTxData {
     /// The start time of the transmission.
     pub tx_start: Date,

--- a/src/contact_manager/segmentation/mod.rs
+++ b/src/contact_manager/segmentation/mod.rs
@@ -1,5 +1,6 @@
 use crate::contact::ContactInfo;
-use crate::parsing::{Lexer, ParsingState};
+use crate::errors::ASABRError;
+use crate::parsing::{Lexer, LexerOutput};
 use crate::types::{DataRate, Date, Duration, Token, Volume};
 
 pub mod pseg;
@@ -245,49 +246,19 @@ pub trait BaseSegmentationManager {
 ///
 /// # Returns
 ///
-/// Returns a `ParsingState`:
+/// Returns a `Result<LexerOutput<T>, ASABRError>`:
 /// - `Finished((start, end, val))` if the interval is successfully parsed.
-/// - `Error(msg)` if there is an error during parsing.
-/// - `EOF` if an unexpected end-of-file is encountered during parsing.
-fn parse_interval<T: std::str::FromStr>(lexer: &mut dyn Lexer) -> ParsingState<(Date, Date, T)> {
-    let val: T;
+/// - An error from Date::parse(), or if an unexpected end-of-file is encountered during parsing.
+fn parse_interval<T: std::str::FromStr>(
+    lexer: &mut dyn Lexer,
+) -> Result<(Date, Date, T), ASABRError> {
+    let start: Date = Date::parse(lexer)?;
 
-    let start_state = Date::parse(lexer);
-    let start: Date = match start_state {
-        ParsingState::Finished(value) => value,
-        ParsingState::Error(msg) => return ParsingState::Error(msg),
-        ParsingState::EOF => {
-            return ParsingState::Error(format!(
-                "Parsing failed ({})",
-                lexer.get_current_position()
-            ));
-        }
-    };
+    let end: Date = Date::parse(lexer)?;
 
-    let end_state = Date::parse(lexer);
-    let end: Date = match end_state {
-        ParsingState::Finished(value) => value,
-        ParsingState::Error(msg) => return ParsingState::Error(msg),
-        ParsingState::EOF => {
-            return ParsingState::Error(format!(
-                "Parsing failed ({})",
-                lexer.get_current_position()
-            ));
-        }
-    };
+    let val: T = T::parse(lexer)?;
 
-    let val_state = T::parse(lexer);
-    match val_state {
-        ParsingState::Finished(value) => val = value,
-        ParsingState::Error(msg) => return ParsingState::Error(msg),
-        ParsingState::EOF => {
-            return ParsingState::Error(format!(
-                "Parsing failed ({})",
-                lexer.get_current_position()
-            ));
-        }
-    }
-    ParsingState::Finished((start, end, val))
+    Ok((start, end, val))
 }
 
 /// Parses a `BaseSegmentationManager` from the lexer, extracting the rate and delay intervals.
@@ -298,60 +269,40 @@ fn parse_interval<T: std::str::FromStr>(lexer: &mut dyn Lexer) -> ParsingState<(
 ///
 /// # Returns
 ///
-/// Returns a `ParsingState` indicating whether parsing was successful (`Finished`) or encountered an error (`Error`).
-fn parse<M: BaseSegmentationManager>(lexer: &mut dyn Lexer) -> ParsingState<M> {
+/// Returns a `Result<LexerOutput<T>, ASABRError>` indicating whether parsing was successful (`Finished`)
+/// or encountered an error.
+fn parse<M: BaseSegmentationManager>(lexer: &mut dyn Lexer) -> Result<M, ASABRError> {
     let mut rate_intervals: Vec<Segment<DataRate>> = Vec::new();
     let mut delay_intervals: Vec<Segment<Duration>> = Vec::new();
 
     loop {
-        let res = lexer.lookup();
-        match res {
-            ParsingState::EOF => break,
-            ParsingState::Error(e) => return ParsingState::Error(e),
-            ParsingState::Finished(interval_type) => match interval_type.as_str() {
-                "delay" => {
-                    lexer.consume_next_token();
-                    let state = parse_interval::<Duration>(lexer);
-                    match state {
-                        ParsingState::Finished((start, end, delay)) => {
-                            delay_intervals.push(Segment {
-                                start,
-                                end,
-                                val: delay,
-                            });
-                        }
-                        ParsingState::EOF => {
-                            return ParsingState::EOF;
-                        }
-                        ParsingState::Error(msg) => {
-                            return ParsingState::Error(msg);
-                        }
-                    }
-                }
-                "rate" => {
-                    lexer.consume_next_token();
-                    let state = parse_interval::<DataRate>(lexer);
-                    match state {
-                        ParsingState::Finished((start, end, rate)) => {
-                            rate_intervals.push(Segment {
-                                start,
-                                end,
-                                val: rate,
-                            });
-                        }
-                        ParsingState::EOF => {
-                            return ParsingState::EOF;
-                        }
-                        ParsingState::Error(msg) => {
-                            return ParsingState::Error(msg);
-                        }
-                    }
-                }
-                _ => {
-                    break;
-                }
-            },
+        let interval_type = match lexer.lookup()? {
+            LexerOutput::EOF => break,
+            LexerOutput::Finished(t) => t,
+        };
+        match interval_type.as_str() {
+            "delay" => {
+                lexer.consume_next_token()?;
+                let (start, end, delay) = parse_interval::<Duration>(lexer)?;
+                delay_intervals.push(Segment {
+                    start,
+                    end,
+                    val: delay,
+                });
+            }
+            "rate" => {
+                lexer.consume_next_token()?;
+                let (start, end, rate) = parse_interval::<DataRate>(lexer)?;
+                rate_intervals.push(Segment {
+                    start,
+                    end,
+                    val: rate,
+                });
+            }
+            _ => {
+                break;
+            }
         }
     }
-    ParsingState::Finished(M::new(rate_intervals, delay_intervals))
+    Ok(M::new(rate_intervals, delay_intervals))
 }

--- a/src/contact_manager/segmentation/pseg.rs
+++ b/src/contact_manager/segmentation/pseg.rs
@@ -7,7 +7,8 @@ use crate::{
         ContactManager, ContactManagerTxData,
         segmentation::{BaseSegmentationManager, Segment},
     },
-    parsing::{Lexer, Parser, ParsingState},
+    errors::ASABRError,
+    parsing::{Lexer, Parser},
     types::{DataRate, Date, Duration, Priority},
 };
 
@@ -244,8 +245,9 @@ impl Parser<PSegmentationManager> for PSegmentationManager {
     ///
     /// # Returns
     ///
-    /// Returns a `ParsingState` indicating whether parsing was successful (`Finished`) or encountered an error (`Error`).
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<PSegmentationManager> {
+    /// Returns a `Result<LexerOutput<T>, ASABRError>` indicating whether parsing was successful
+    /// (`Finished`) or encountered an error.
+    fn parse(lexer: &mut dyn Lexer) -> Result<PSegmentationManager, ASABRError> {
         super::parse::<PSegmentationManager>(lexer)
     }
 }
@@ -308,16 +310,12 @@ mod tests {
 
             assert_eq!(
                 dry_run_res, schedule_tx_res,
-                "TEST N°{} FAILED: dry_run and schedule_tx doesn't match.\n",
-                i
+                "TEST N°{i} FAILED: dry_run and schedule_tx doesn't match.\n",
             );
+            let is_some = schedule_tx_res.is_some();
             assert_eq!(
-                schedule_tx_res.is_some(),
-                *expect_success,
-                "TEST N°{} FAILED: expected: {} actual: {}",
-                i,
-                expect_success,
-                schedule_tx_res.is_some()
+                is_some, *expect_success,
+                "TEST N°{i} FAILED: expected: {expect_success} actual: {is_some}",
             );
         }
 

--- a/src/contact_manager/segmentation/seg.rs
+++ b/src/contact_manager/segmentation/seg.rs
@@ -7,7 +7,8 @@ use crate::{
         ContactManager, ContactManagerTxData,
         segmentation::{BaseSegmentationManager, Segment},
     },
-    parsing::{DispatchParser, Lexer, Parser, ParsingState},
+    errors::ASABRError,
+    parsing::{DispatchParser, Lexer, Parser},
     types::{DataRate, Date, Duration},
 };
 
@@ -228,8 +229,9 @@ impl Parser<SegmentationManager> for SegmentationManager {
     ///
     /// # Returns
     ///
-    /// Returns a `ParsingState` indicating whether parsing was successful (`Finished`) or encountered an error (`Error`).
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<SegmentationManager> {
+    /// Returns a `Result<LexerOutput<T>, ASABRError>` indicating whether parsing was successful
+    /// (`Finished`) or encountered an error.
+    fn parse(lexer: &mut dyn Lexer) -> Result<SegmentationManager, ASABRError> {
         super::parse::<SegmentationManager>(lexer)
     }
 }
@@ -303,42 +305,35 @@ mod tests {
 
                 assert!(
                     schedule_tx_res.is_some(),
-                    "TEST N°{} FAILED: schedule_tx failed unexpectedly.",
-                    i
+                    "TEST N°{i} FAILED: schedule_tx failed unexpectedly."
                 );
 
                 assert_eq!(
                     dry_run_res.is_some(),
                     schedule_tx_res.is_some(),
-                    "TEST N°{} FAILED: dry_run_tx and schedule_tx do not match.",
-                    i
+                    "TEST N°{i} FAILED: dry_run_tx and schedule_tx do not match."
                 );
 
                 if let (Some(dry), Some(sched)) = (dry_run_res, schedule_tx_res) {
                     assert_eq!(
                         dry.tx_start, sched.tx_start,
-                        "TEST N°{} FAILED: tx_start mismatch.",
-                        i
+                        "TEST N°{i} FAILED: tx_start mismatch."
                     );
                     assert_eq!(
                         dry.tx_end, sched.tx_end,
-                        "TEST N°{} FAILED: tx_end mismatch.",
-                        i
+                        "TEST N°{i} FAILED: tx_end mismatch."
                     );
                     assert_eq!(
                         dry.expiration, sched.expiration,
-                        "TEST N°{} FAILED: expiration mismatch.",
-                        i
+                        "TEST N°{i} FAILED: expiration mismatch."
                     );
                     assert_eq!(
                         dry.rx_start, sched.rx_start,
-                        "TEST N°{} FAILED: rx_start mismatch.",
-                        i
+                        "TEST N°{i} FAILED: rx_start mismatch."
                     );
                     assert_eq!(
                         dry.rx_end, sched.rx_end,
-                        "TEST N°{} FAILED: rx_end mismatch.",
-                        i
+                        "TEST N°{i} FAILED: rx_end mismatch."
                     );
                 }
             }

--- a/src/contact_plan/asabr_file_lexer.rs
+++ b/src/contact_plan/asabr_file_lexer.rs
@@ -3,7 +3,10 @@ use std::{
     io::{self, BufRead, BufReader},
 };
 
-use crate::parsing::{Lexer, ParsingState};
+use crate::{
+    errors::ASABRError,
+    parsing::{Lexer, LexerOutput},
+};
 
 /// A lexer for tokenizing text from a file.
 ///
@@ -91,15 +94,12 @@ impl Lexer for FileLexer {
     ///
     /// # Returns
     ///
-    /// Returns `ParsingState::Finished(String)` if a token is successfully consumed,
-    /// `ParsingState::EOF` if the end of the file is reached, or `ParsingState::Error` if an error occurs.
-    fn consume_next_token(&mut self) -> ParsingState<String> {
+    /// Returns `Ok(LexerOutput::Finished(String))` if a token is successfully consumed,
+    /// `Ok(LexerOutput::EOF)` if the end of the file is reached, or `Err` if an error occurs.
+    fn consume_next_token(&mut self) -> Result<LexerOutput<String>, ASABRError> {
         if self.buffer_stack.is_empty() {
-            let res = self.read_next_words();
-            match res {
-                Ok(_) => {}
-                Err(e) => return ParsingState::Error(e.to_string()),
-            }
+            self.read_next_words()
+                .map_err(|e| ASABRError::ParsingError(e.to_string()))?;
         }
 
         let next_word = self.buffer_stack.pop();
@@ -110,9 +110,9 @@ impl Lexer for FileLexer {
                     self.current_line = self.lookup_current_line;
                 }
                 self.token_position += 1;
-                ParsingState::Finished(word)
+                Ok(LexerOutput::Finished(word))
             }
-            None => ParsingState::EOF,
+            None => Ok(LexerOutput::EOF),
         }
     }
 
@@ -133,21 +133,18 @@ impl Lexer for FileLexer {
     ///
     /// # Returns
     ///
-    /// Returns `ParsingState::Finished(String)` if a token is available,
-    /// `ParsingState::EOF` if the end of the file is reached, or `ParsingState::Error` if an error occurs.
-    fn lookup(&mut self) -> ParsingState<String> {
+    /// Returns `Ok(LexerOutput::Finished(String))` if a token is available,
+    /// `Ok(LexerOutput::EOF)` if the end of the file is reached, or `Err` if an error occurs.
+    fn lookup(&mut self) -> Result<LexerOutput<String>, ASABRError> {
         if self.buffer_stack.is_empty() {
-            let res = self.read_next_words();
-            match res {
-                Ok(_) => {}
-                Err(e) => return ParsingState::Error(e.to_string()),
-            }
+            self.read_next_words()
+                .map_err(|e| ASABRError::ParsingError(e.to_string()))?;
         }
 
         let next_word = self.buffer_stack.last();
         match next_word {
-            Some(word) => ParsingState::Finished(word.to_string()),
-            None => ParsingState::EOF,
+            Some(word) => Ok(LexerOutput::Finished(word.to_string())),
+            None => Ok(LexerOutput::EOF),
         }
     }
 }

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -32,7 +32,8 @@ impl RealNodeType {
 struct Builder<NM: NodeManager, CM: ContactManager> {
     // for output
     vertices: Vec<Vertex<NM>>,
-    vnode_map: NodeIDMap,
+    vnode_to_rids_map: NodeIDMap,
+    rid_to_vnodes_map: NodeIDMap,
     contacts: Vec<Contact<NM, CM>>,
 
     // Unicity
@@ -43,7 +44,8 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
     fn new() -> Self {
         Self {
             vertices: Vec::new(),
-            vnode_map: HashMap::new(),
+            vnode_to_rids_map: HashMap::new(),
+            rid_to_vnodes_map: HashMap::new(),
             contacts: Vec::new(),
             node_names: HashSet::new(),
         }
@@ -51,7 +53,7 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
 
     #[inline(always)]
     fn real_nodes_count(&self) -> usize {
-        self.vertices.len() - self.vnode_map.len()
+        self.vertices.len() - self.vnode_to_rids_map.len()
     }
 
     // Checkers
@@ -86,10 +88,7 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
     fn check_enodes_have_vnodes(&self) -> Result<(), ASABRError> {
         for vertex in &self.vertices {
             if let Vertex::ENode(enode) = vertex
-                && !self
-                    .vnode_map
-                    .values()
-                    .any(|rids| rids.contains(&enode.info.id))
+                && !self.rid_to_vnodes_map.contains_key(&enode.info.id)
             {
                 return Err(ASABRError::ParsingError(format!(
                     "ENode '{}' (id: {}) is not labeled by any vnode",
@@ -130,9 +129,13 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
         self.register_name(vnode.name)?;
         for rid in &vnode.rids {
             self.check_real_id(*rid)?;
+            self.rid_to_vnodes_map
+                .entry(*rid)
+                .or_default()
+                .push(vnode.vid);
         }
         self.vertices.push(Vertex::VNode(vnode.vid));
-        self.vnode_map.insert(vnode.vid, vnode.rids);
+        self.vnode_to_rids_map.insert(vnode.vid, vnode.rids);
         Ok(())
     }
 
@@ -142,7 +145,10 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
         ContactPlan::new(
             self.vertices,
             self.contacts,
-            Some(VirtualNodeMap::new(self.vnode_map)),
+            Some(VirtualNodeMap::new(
+                self.vnode_to_rids_map,
+                self.rid_to_vnodes_map,
+            )),
         )
     }
 }

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -4,8 +4,8 @@ use crate::{
     contact_plan::ContactPlan,
     node::{Node, NodeInfo},
     parsing::{Parser, StaticMarkerMap},
-    types::{NodeID, NodeIDMap, NodeName, VirtualNodeMap},
-    vnode::VirtualNodeInfo,
+    types::{NodeID, NodeIDMap, NodeName},
+    vnode::{VirtualNodeInfo, VirtualNodeMap},
 };
 use crate::{
     node_manager::NodeManager,

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -2,6 +2,7 @@ use crate::{
     contact::{Contact, ContactInfo},
     contact_manager::ContactManager,
     contact_plan::ContactPlan,
+    errors::ASABRError,
     node::{Node, NodeInfo},
     parsing::{Parser, StaticMarkerMap},
     types::{NodeID, NodeIDMap, NodeName},
@@ -10,7 +11,7 @@ use crate::{
 };
 use crate::{
     node_manager::NodeManager,
-    parsing::{DispatchParser, Lexer, ParsingState, parse_components},
+    parsing::{DispatchParser, Lexer, LexerOutput, parse_components},
 };
 use std::collections::{HashMap, HashSet};
 
@@ -55,34 +56,34 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
 
     // Checkers
 
-    fn check_real_id(&self, id: NodeID) -> Result<(), String> {
+    fn check_real_id(&self, id: NodeID) -> Result<(), ASABRError> {
         if (id as usize) >= self.real_nodes_count() {
-            return Err(
+            return Err(ASABRError::ParsingError(
                 "Contact tx/rx ids or virtual node rids must match an already declared real node id".to_string(),
-            );
+            ));
         }
         Ok(())
     }
 
-    fn check_new_real_id(&self, id: NodeID) -> Result<(), String> {
+    fn check_new_real_id(&self, id: NodeID) -> Result<(), ASABRError> {
         if (id as usize) != self.real_nodes_count() {
-            return Err(
+            return Err(ASABRError::ParsingError(
                 "Declare real nodes before virtual nodes, in increasing id order".to_string(),
-            );
+            ));
         }
         Ok(())
     }
 
-    fn check_new_virtual_id(&self, id: NodeID) -> Result<(), String> {
+    fn check_new_virtual_id(&self, id: NodeID) -> Result<(), ASABRError> {
         if (id as usize) != self.vertices.len() {
-            return Err(
+            return Err(ASABRError::ParsingError(
                 "Declare virtual nodes after the real nodes, in increasing id order".to_string(),
-            );
+            ));
         }
         Ok(())
     }
 
-    fn check_enodes_have_vnodes(&self) -> Result<(), String> {
+    fn check_enodes_have_vnodes(&self) -> Result<(), ASABRError> {
         for vertex in &self.vertices {
             if let Vertex::ENode(enode) = vertex
                 && !self
@@ -90,10 +91,10 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
                     .values()
                     .any(|rids| rids.contains(&enode.info.id))
             {
-                return Err(format!(
+                return Err(ASABRError::ParsingError(format!(
                     "ENode '{}' (id: {}) is not labeled by any vnode",
                     enode.info.name, enode.info.id,
-                ));
+                )));
             }
         }
         Ok(())
@@ -101,28 +102,30 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
 
     // Adders
 
-    fn register_name(&mut self, name: String) -> Result<(), String> {
+    fn register_name(&mut self, name: String) -> Result<(), ASABRError> {
         if !self.node_names.insert(name) {
-            return Err("Another vertex shares this name".to_string());
+            return Err(ASABRError::ParsingError(
+                "Another vertex shares this name".to_string(),
+            ));
         }
         Ok(())
     }
 
-    fn add_real_node(&mut self, node: Node<NM>, node_type: RealNodeType) -> Result<(), String> {
+    fn add_real_node(&mut self, node: Node<NM>, node_type: RealNodeType) -> Result<(), ASABRError> {
         self.check_new_real_id(node.get_node_id())?;
         self.register_name(node.get_node_name())?;
         self.vertices.push(node_type.to_vertex(node));
         Ok(())
     }
 
-    fn add_contact(&mut self, contact: Contact<NM, CM>) -> Result<(), String> {
+    fn add_contact(&mut self, contact: Contact<NM, CM>) -> Result<(), ASABRError> {
         self.check_real_id(contact.info.tx_node_id)?;
         self.check_real_id(contact.info.rx_node_id)?;
         self.contacts.push(contact);
         Ok(())
     }
 
-    fn add_virtual_node(&mut self, vnode: VirtualNodeInfo) -> Result<(), String> {
+    fn add_virtual_node(&mut self, vnode: VirtualNodeInfo) -> Result<(), ASABRError> {
         self.check_new_virtual_id(vnode.vid)?;
         self.register_name(vnode.name)?;
         for rid in &vnode.rids {
@@ -134,14 +137,13 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
     }
 
     // Builder
-    fn build(self) -> Result<ContactPlan<NM, CM>, String> {
+    fn build(self) -> Result<ContactPlan<NM, CM>, ASABRError> {
         self.check_enodes_have_vnodes()?;
         ContactPlan::new(
             self.vertices,
             self.contacts,
             Some(VirtualNodeMap::new(self.vnode_map)),
         )
-        .map_err(|_| "Failed to create contact plan".to_string())
     }
 }
 
@@ -152,18 +154,15 @@ impl ASABRContactPlan {
     fn parse_node<NM: NodeManager + DispatchParser<NM> + Parser<NM>>(
         lexer: &mut dyn Lexer,
         node_marker_map: &Option<&StaticMarkerMap<NM>>,
-    ) -> Result<Node<NM>, String> {
-        let node_opt = parse_components::<NodeInfo, NM>(lexer, *node_marker_map);
-        match node_opt {
-            ParsingState::EOF => Err("Unexpected EOF".to_string()),
-            ParsingState::Error(msg) => Err(msg),
-            ParsingState::Finished((info, manager)) => {
-                let Some(node) = Node::try_new(info, manager) else {
-                    return Err(format!("Malformed node ({})", lexer.get_current_position()));
-                };
-                Ok(node)
-            }
-        }
+    ) -> Result<Node<NM>, ASABRError> {
+        let (info, manager) = parse_components::<NodeInfo, NM>(lexer, *node_marker_map)?;
+        let Some(node) = Node::try_new(info, manager) else {
+            return Err(ASABRError::ParsingError(format!(
+                "Malformed node ({})",
+                lexer.get_current_position()
+            )));
+        };
+        Ok(node)
     }
 
     pub fn parse<
@@ -173,75 +172,50 @@ impl ASABRContactPlan {
         lexer: &mut dyn Lexer,
         node_marker_map: Option<&StaticMarkerMap<NM>>,
         contact_marker_map: Option<&StaticMarkerMap<CM>>,
-    ) -> Result<ContactPlan<NM, CM>, String> {
+    ) -> Result<ContactPlan<NM, CM>, ASABRError> {
         let mut builder = Builder::new();
 
         loop {
-            let res = lexer.consume_next_token();
+            let element_type = match lexer.consume_next_token()? {
+                LexerOutput::EOF => break,
+                LexerOutput::Finished(t) => t,
+            };
 
-            match res {
-                ParsingState::EOF => {
-                    break;
-                }
-                ParsingState::Error(msg) => {
-                    return Err(msg);
-                }
-                ParsingState::Finished(element_type) => match element_type.as_str() {
-                    "contact" => {
-                        let contact_opt =
-                            parse_components::<ContactInfo, CM>(lexer, contact_marker_map);
-                        match contact_opt {
-                            ParsingState::EOF => {
-                                break;
-                            }
-                            ParsingState::Error(msg) => {
-                                return Err(msg);
-                            }
-                            ParsingState::Finished((info, manager)) => {
-                                let Some(contact) = Contact::try_new(info, manager) else {
-                                    return Err(format!(
-                                        "Malformed contact ({})",
-                                        lexer.get_current_position()
-                                    ));
-                                };
-                                builder.add_contact(contact)?;
-                            }
-                        }
-                    }
-                    "node" => {
-                        builder.add_real_node(
-                            Self::parse_node(lexer, &node_marker_map)?,
-                            RealNodeType::Node,
-                        )?;
-                    }
-                    "enode" => {
-                        builder.add_real_node(
-                            Self::parse_node(lexer, &node_marker_map)?,
-                            RealNodeType::Enode,
-                        )?;
-                    }
-                    "vnode" => {
-                        let vnode_opt =
-                            parse_components::<VirtualNodeInfo, NM>(lexer, node_marker_map);
-                        match vnode_opt {
-                            ParsingState::EOF => {
-                                break;
-                            }
-                            ParsingState::Error(msg) => {
-                                return Err(msg);
-                            }
-                            ParsingState::Finished((info, _)) => {
-                                builder.add_virtual_node(info)?;
-                            }
-                        }
-                    }
-                    _ => {
-                        return Err(format!(
-                            "Unrecognized CP element ({})",
+            match element_type.as_str() {
+                "contact" => {
+                    let (info, manager) =
+                        parse_components::<ContactInfo, CM>(lexer, contact_marker_map)?;
+                    let Some(contact) = Contact::try_new(info, manager) else {
+                        return Err(ASABRError::ParsingError(format!(
+                            "Malformed contact ({})",
                             lexer.get_current_position()
-                        ));
-                    }
-                },
+                        )));
+                    };
+                    builder.add_contact(contact)?;
+                }
+                "node" => {
+                    builder.add_real_node(
+                        Self::parse_node(lexer, &node_marker_map)?,
+                        RealNodeType::Node,
+                    )?;
+                }
+                "enode" => {
+                    builder.add_real_node(
+                        Self::parse_node(lexer, &node_marker_map)?,
+                        RealNodeType::Enode,
+                    )?;
+                }
+                "vnode" => {
+                    let (info, _) =
+                        parse_components::<VirtualNodeInfo, NM>(lexer, node_marker_map)?;
+                    builder.add_virtual_node(info)?;
+                }
+                _ => {
+                    return Err(ASABRError::ParsingError(format!(
+                        "Unrecognized CP element ({})",
+                        lexer.get_current_position()
+                    )));
+                }
             }
         }
         builder.build()

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -12,171 +12,160 @@ use crate::{
     node_manager::NodeManager,
     parsing::{DispatchParser, Lexer, ParsingState, parse_components},
 };
-use std::{cmp::max, collections::HashSet};
+use std::collections::{HashMap, HashSet};
 
-/// `ContactPlan` is responsible for managing and validating the parsing of contacts and nodes
-/// in a network configuration. It tracks known node IDs and names to ensure uniqueness,
-/// and verifies that the node IDs match between contacts and nodes.
+enum RealNodeType {
+    Node,
+    Enode,
+}
+
+impl RealNodeType {
+    fn to_vertex<NM: NodeManager>(&self, node: Node<NM>) -> Vertex<NM> {
+        match self {
+            RealNodeType::Node => Vertex::INode(node),
+            RealNodeType::Enode => Vertex::ENode(node),
+        }
+    }
+}
+
+struct Builder<NM: NodeManager, CM: ContactManager> {
+    // for output
+    vertices: Vec<Vertex<NM>>,
+    vnode_map: NodeIDMap,
+    contacts: Vec<Contact<NM, CM>>,
+
+    // Unicity
+    node_names: HashSet<NodeName>,
+}
+
+impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
+    fn new() -> Self {
+        Self {
+            vertices: Vec::new(),
+            vnode_map: HashMap::new(),
+            contacts: Vec::new(),
+            node_names: HashSet::new(),
+        }
+    }
+
+    #[inline(always)]
+    fn real_nodes_count(&self) -> usize {
+        self.vertices.len() - self.vnode_map.len()
+    }
+
+    // Checkers
+
+    fn check_real_id(&self, id: NodeID) -> Result<(), String> {
+        if (id as usize) >= self.real_nodes_count() {
+            return Err(
+                "Contact tx/rx ids or virtual node rids must match an already declared real node id".to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    fn check_new_real_id(&self, id: NodeID) -> Result<(), String> {
+        if (id as usize) != self.real_nodes_count() {
+            return Err(
+                "Declare real nodes before virtual nodes, in increasing id order".to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    fn check_new_virtual_id(&self, id: NodeID) -> Result<(), String> {
+        if (id as usize) != self.vertices.len() {
+            return Err(
+                "Declare virtual nodes after the real nodes, in increasing id order".to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    fn check_enodes_have_vnodes(&self) -> Result<(), String> {
+        for vertex in &self.vertices {
+            if let Vertex::ENode(enode) = vertex
+                && !self
+                    .vnode_map
+                    .values()
+                    .any(|rids| rids.contains(&enode.info.id))
+            {
+                return Err(format!(
+                    "ENode '{}' (id: {}) is not labeled by any vnode",
+                    enode.info.name, enode.info.id,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    // Adders
+
+    fn register_name(&mut self, name: String) -> Result<(), String> {
+        if !self.node_names.insert(name) {
+            return Err("Another vertex shares this name".to_string());
+        }
+        Ok(())
+    }
+
+    fn add_real_node(&mut self, node: Node<NM>, node_type: RealNodeType) -> Result<(), String> {
+        self.check_new_real_id(node.get_node_id())?;
+        self.register_name(node.get_node_name())?;
+        self.vertices.push(node_type.to_vertex(node));
+        Ok(())
+    }
+
+    fn add_contact(&mut self, contact: Contact<NM, CM>) -> Result<(), String> {
+        self.check_real_id(contact.info.tx_node_id)?;
+        self.check_real_id(contact.info.rx_node_id)?;
+        self.contacts.push(contact);
+        Ok(())
+    }
+
+    fn add_virtual_node(&mut self, vnode: VirtualNodeInfo) -> Result<(), String> {
+        self.check_new_virtual_id(vnode.vid)?;
+        self.register_name(vnode.name)?;
+        for rid in &vnode.rids {
+            self.check_real_id(*rid)?;
+        }
+        self.vertices.push(Vertex::VNode(vnode.vid));
+        self.vnode_map.insert(vnode.vid, vnode.rids);
+        Ok(())
+    }
+
+    // Builder
+    fn build(self) -> Result<ContactPlan<NM, CM>, String> {
+        self.check_enodes_have_vnodes()?;
+        ContactPlan::new(
+            self.vertices,
+            self.contacts,
+            Some(VirtualNodeMap::new(self.vnode_map)),
+        )
+        .map_err(|_| "Failed to create contact plan".to_string())
+    }
+}
+
 pub struct ASABRContactPlan {}
 
 impl ASABRContactPlan {
-    /// Adds a contact to the contact list, ensuring that the maximum node ID in the contacts is updated.
-    ///
-    /// # Parameters
-    ///
-    /// * `contact` - The `Contact` to be added to the plan.
-    /// * `contacts` - A mutable reference to a vector of contacts, where the new contact will be stored.
-    /// * `max_node_id_in_contacts` - A mutable reference to the current maximum node ID found in contacts.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `CM` - A generic type that implements the `ContactManager` trait, used to manage the contact.
-    fn add_contact<NM: NodeManager, CM: ContactManager>(
-        contact: Contact<NM, CM>,
-        contacts: &mut Vec<Contact<NM, CM>>,
-        vnode_map: &NodeIDMap,
-        max_node_id_in_contacts: &mut usize,
-    ) -> Result<(), String> {
-        if vnode_map.contains_key(&contact.info.rx_node_id) {
-            return Err(format!(
-                "Contact Rx node ({}) cannot be a virtual node",
-                contact.info.rx_node_id
-            ));
-        } else if vnode_map.contains_key(&contact.info.tx_node_id) {
-            return Err(format!(
-                "Contact Tx node ({}) cannot be a virtual node",
-                contact.info.tx_node_id
-            ));
+    // Helper for enode/node duplication
+    fn parse_node<NM: NodeManager + DispatchParser<NM> + Parser<NM>>(
+        lexer: &mut dyn Lexer,
+        node_marker_map: &Option<&StaticMarkerMap<NM>>,
+    ) -> Result<Node<NM>, String> {
+        let node_opt = parse_components::<NodeInfo, NM>(lexer, *node_marker_map);
+        match node_opt {
+            ParsingState::EOF => Err("Unexpected EOF".to_string()),
+            ParsingState::Error(msg) => Err(msg),
+            ParsingState::Finished((info, manager)) => {
+                let Some(node) = Node::try_new(info, manager) else {
+                    return Err(format!("Malformed node ({})", lexer.get_current_position()));
+                };
+                Ok(node)
+            }
         }
-
-        let value = max(contact.get_tx_node_id(), contact.get_rx_node_id());
-        *max_node_id_in_contacts = max(*max_node_id_in_contacts, value.into());
-        contacts.push(contact);
-        Ok(())
     }
 
-    /// Adds a node to the node list, ensuring that the node ID and node name are unique.
-    /// Returns an error if a node with the same ID or name has already been added.
-    ///
-    /// # Parameters
-    ///
-    /// * `node` - The `Node` to be added to the plan.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<(), String>` - Returns `Ok(())` if the node was successfully added, or an error message
-    ///   if there is a conflict with an existing node ID or name.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `NM` - A generic type that implements the `NodeManager` trait, used to manage the node.
-    fn add_node<NM: NodeManager>(
-        node: &Node<NM>,
-        max_node_id_in_nodes: &mut usize,
-        known_node_ids: &mut HashSet<NodeID>,
-        known_node_names: &mut HashSet<NodeName>,
-    ) -> Result<(), String> {
-        let node_id = node.get_node_id();
-        let node_name = node.get_node_name();
-
-        if known_node_ids.contains(&node_id) {
-            return Err(format!("Two nodes have the same id ({node_id})"));
-        }
-        if known_node_names.contains(&node_name) {
-            return Err(format!("Two nodes have the same name ({node_name})"));
-        }
-        *max_node_id_in_nodes = max(*max_node_id_in_nodes, node_id.into());
-        known_node_ids.insert(node_id);
-        known_node_names.insert(node_name);
-        Ok(())
-    }
-
-    /// Adds a vnode to the vnode map, performing checks such as bounds on on the vnode IDs.
-    /// Returns an error if the checks do not pass.
-    ///
-    /// # Parameters
-    ///
-    /// * `vnode` - The `Node` to be added to the plan, constructed from VirtualNodeInfo.
-    /// * `vnode_map` - A mutable reference to a NodeIDMap HashMap, where the new vid and rids will be stored.
-    /// * `rids` - The vector of NodeIDs to be mapped to this virtual node.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<(), String>` - Returns `Ok(())` if the node was successfully added, or an error message
-    ///   if any of the error control checks fail.
-    fn add_vnode<NM: NodeManager>(
-        vnode_info: VirtualNodeInfo,
-        vertices: &mut Vec<Vertex<NM>>,
-        vnode_map: &mut NodeIDMap,
-        known_node_ids: &HashSet<NodeID>,
-        max_node_id_in_nodes: &mut usize,
-    ) -> Result<(), String> {
-        // Error control checks
-        // 1. A vnode ID must come after all the real node IDs it references.
-
-        // `max_node_id_in_nodes` is #nodes + #vnodes including the current one.
-        // `vnode_map.len()` hasn't been updated yet so it excludes the current one.
-        // Thus:
-        let max_real_node_id = (*max_node_id_in_nodes - 1) - vnode_map.len();
-
-        if usize::from(vnode_info.vid) <= max_real_node_id {
-            return Err(format!(
-                "Virtual node ID is in the range of its real node IDs (vid {} <= {})",
-                vnode_info.vid, max_real_node_id
-            ));
-        }
-
-        // 2. A vnode's rids mut be in range and must not be duplicates.
-        let mut known_rids: HashSet<NodeID> = HashSet::new();
-        for rid in &vnode_info.rids {
-            if usize::from(*rid) > max_real_node_id {
-                return Err(format!(
-                    "Node ID out of range ({rid} > {max_real_node_id}) in virtual node definition"
-                ));
-            }
-            if !known_node_ids.contains(rid) {
-                return Err(format!(
-                    "Node ID referenced in in virtual node definition does not exist ({rid})"
-                ));
-            }
-            if known_rids.contains(rid) {
-                return Err(format!(
-                    "Node ID duplicate ({rid}) in virtual node definition"
-                ));
-            }
-            known_rids.insert(*rid);
-        }
-
-        vnode_map.insert(vnode_info.vid, vnode_info.rids);
-        vertices.push(Vertex::VNode(vnode_info.vid));
-
-        Ok(())
-    }
-
-    /// Parses nodes and contacts from a lexer, while ensuring node ID and name uniqueness
-    /// and consistency between node definitions and contacts.
-    ///
-    /// The lexer processes tokens from input text, and this method associates each parsed element
-    /// with a node or a contact. It uses marker maps to recognize elements based on predefined markers.
-    /// Do not provide the associated marker map if you plan to use a dyn NodeManager or dyn ContactManager.
-    ///
-    /// # Parameters
-    ///
-    /// * `lexer` - A mutable reference to a `Lexer` instance, which provides tokens from the input text.
-    /// * `node_marker_map` - An optional hash map that associates node markers with parsing functions.
-    /// * `contact_marker_map` - An optional hash map that associates contact markers with parsing functions.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<ContactPlan<NM, NM, CM>, String>` - Returns a `ContactPlan` containing vectors of parsed
-    ///   nodes and contacts, or an error message if there is an issue during parsing.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `NM` - A type that implements the `NodeManager`, Parser<NM>, and `DispatchParser<NM>` traits, representing
-    ///   the type of the nodes being managed and parsed.
-    /// * `CM` - A type that implements the `ContactManager`, Parser<CM>, and `DispatchParser<CM>` traits, representing
-    ///   the type of the contacts being managed and parsed.
     pub fn parse<
         NM: NodeManager + DispatchParser<NM> + Parser<NM>,
         CM: ContactManager + DispatchParser<CM> + Parser<CM>,
@@ -185,15 +174,7 @@ impl ASABRContactPlan {
         node_marker_map: Option<&StaticMarkerMap<NM>>,
         contact_marker_map: Option<&StaticMarkerMap<CM>>,
     ) -> Result<ContactPlan<NM, CM>, String> {
-        let mut contacts: Vec<Contact<NM, CM>> = Vec::new();
-        let mut vertices: Vec<Vertex<NM>> = Vec::new();
-        let mut vnode_map: NodeIDMap = NodeIDMap::new();
-
-        // These include nodes and vnodes
-        let mut known_node_ids: HashSet<NodeID> = HashSet::new();
-        let mut known_node_names: HashSet<NodeName> = HashSet::new();
-        let mut max_node_id_in_contacts: usize = 0;
-        let mut max_node_id_in_nodes: usize = 0;
+        let mut builder = Builder::new();
 
         loop {
             let res = lexer.consume_next_token();
@@ -207,9 +188,9 @@ impl ASABRContactPlan {
                 }
                 ParsingState::Finished(element_type) => match element_type.as_str() {
                     "contact" => {
-                        let contact =
+                        let contact_opt =
                             parse_components::<ContactInfo, CM>(lexer, contact_marker_map);
-                        match contact {
+                        match contact_opt {
                             ParsingState::EOF => {
                                 break;
                             }
@@ -223,51 +204,26 @@ impl ASABRContactPlan {
                                         lexer.get_current_position()
                                     ));
                                 };
-
-                                Self::add_contact(
-                                    contact,
-                                    &mut contacts,
-                                    &vnode_map,
-                                    &mut max_node_id_in_contacts,
-                                )?;
+                                builder.add_contact(contact)?;
                             }
                         }
                     }
-                    "node" | "enode" => {
-                        let node = parse_components::<NodeInfo, NM>(lexer, node_marker_map);
-                        match node {
-                            ParsingState::EOF => {
-                                break;
-                            }
-                            ParsingState::Error(msg) => {
-                                return Err(msg);
-                            }
-                            ParsingState::Finished((info, manager)) => {
-                                let Some(node) = Node::try_new(info, manager) else {
-                                    return Err(format!(
-                                        "Malformed node ({})",
-                                        lexer.get_current_position()
-                                    ));
-                                };
-
-                                Self::add_node(
-                                    &node,
-                                    &mut max_node_id_in_nodes,
-                                    &mut known_node_ids,
-                                    &mut known_node_names,
-                                )?;
-
-                                match element_type.as_str() {
-                                    "node" => vertices.push(Vertex::INode(node)),
-                                    "enode" => vertices.push(Vertex::ENode(node)),
-                                    _ => unreachable!(),
-                                };
-                            }
-                        }
+                    "node" => {
+                        builder.add_real_node(
+                            Self::parse_node(lexer, &node_marker_map)?,
+                            RealNodeType::Node,
+                        )?;
+                    }
+                    "enode" => {
+                        builder.add_real_node(
+                            Self::parse_node(lexer, &node_marker_map)?,
+                            RealNodeType::Enode,
+                        )?;
                     }
                     "vnode" => {
-                        let vnode = parse_components::<VirtualNodeInfo, NM>(lexer, node_marker_map);
-                        match vnode {
+                        let vnode_opt =
+                            parse_components::<VirtualNodeInfo, NM>(lexer, node_marker_map);
+                        match vnode_opt {
                             ParsingState::EOF => {
                                 break;
                             }
@@ -275,13 +231,7 @@ impl ASABRContactPlan {
                                 return Err(msg);
                             }
                             ParsingState::Finished((info, _)) => {
-                                Self::add_vnode(
-                                    info,
-                                    &mut vertices,
-                                    &mut vnode_map,
-                                    &known_node_ids,
-                                    &mut max_node_id_in_nodes,
-                                )?;
+                                builder.add_virtual_node(info)?;
                             }
                         }
                     }
@@ -294,20 +244,6 @@ impl ASABRContactPlan {
                 },
             }
         }
-        if vnode_map.is_empty() && (max_node_id_in_contacts != max_node_id_in_nodes) {
-            return Err(
-                "The max node numbers for the contact and node definitions do not match"
-                    .to_string(),
-            );
-        }
-        if vertices.is_empty() {
-            return Err("Nodes must be declared".to_string());
-        }
-        if vertices.len() - 1 != max_node_id_in_nodes {
-            return Err("Some node declarations are missing".to_string());
-        }
-
-        ContactPlan::new(vertices, contacts, Some(VirtualNodeMap::new(vnode_map)))
-            .map_err(|_| "Failed to create contact plan".to_string())
+        builder.build()
     }
 }

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -36,19 +36,19 @@ impl ASABRContactPlan {
         vnode_map: &NodeIDMap,
         max_node_id_in_contacts: &mut usize,
     ) -> Result<(), String> {
-        if vnode_map.contains_key(&contact.info.rx_node) {
+        if vnode_map.contains_key(&contact.info.rx_node_id) {
             return Err(format!(
                 "Contact Rx node ({}) cannot be a virtual node",
-                contact.info.rx_node
+                contact.info.rx_node_id
             ));
-        } else if vnode_map.contains_key(&contact.info.tx_node) {
+        } else if vnode_map.contains_key(&contact.info.tx_node_id) {
             return Err(format!(
                 "Contact Tx node ({}) cannot be a virtual node",
-                contact.info.tx_node
+                contact.info.tx_node_id
             ));
         }
 
-        let value = max(contact.get_tx_node(), contact.get_rx_node());
+        let value = max(contact.get_tx_node_id(), contact.get_rx_node_id());
         *max_node_id_in_contacts = max(*max_node_id_in_contacts, value.into());
         contacts.push(contact);
         Ok(())

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -184,7 +184,7 @@ impl ASABRContactPlan {
         lexer: &mut dyn Lexer,
         node_marker_map: Option<&StaticMarkerMap<NM>>,
         contact_marker_map: Option<&StaticMarkerMap<CM>>,
-    ) -> Result<ContactPlan<NM, NM, CM>, String> {
+    ) -> Result<ContactPlan<NM, CM>, String> {
         let mut contacts: Vec<Contact<NM, CM>> = Vec::new();
         let mut nodes: Vec<Node<NM>> = Vec::new();
         let mut vnode_map: NodeIDMap = NodeIDMap::new();

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -5,6 +5,7 @@ use crate::{
     node::{Node, NodeInfo},
     parsing::{Parser, StaticMarkerMap},
     types::{NodeID, NodeIDMap, NodeName},
+    vertex::Vertex,
     vnode::{VirtualNodeInfo, VirtualNodeMap},
 };
 use crate::{
@@ -60,7 +61,6 @@ impl ASABRContactPlan {
     /// # Parameters
     ///
     /// * `node` - The `Node` to be added to the plan.
-    /// * `nodes` - A mutable reference to a vector of nodes, where the new node will be stored.
     ///
     /// # Returns
     ///
@@ -71,8 +71,7 @@ impl ASABRContactPlan {
     ///
     /// * `NM` - A generic type that implements the `NodeManager` trait, used to manage the node.
     fn add_node<NM: NodeManager>(
-        node: Node<NM>,
-        nodes: &mut Vec<Node<NM>>,
+        node: &Node<NM>,
         max_node_id_in_nodes: &mut usize,
         known_node_ids: &mut HashSet<NodeID>,
         known_node_names: &mut HashSet<NodeName>,
@@ -89,7 +88,6 @@ impl ASABRContactPlan {
         *max_node_id_in_nodes = max(*max_node_id_in_nodes, node_id.into());
         known_node_ids.insert(node_id);
         known_node_names.insert(node_name);
-        nodes.push(node);
         Ok(())
     }
 
@@ -106,8 +104,9 @@ impl ASABRContactPlan {
     ///
     /// * `Result<(), String>` - Returns `Ok(())` if the node was successfully added, or an error message
     ///   if any of the error control checks fail.
-    fn add_vnode(
+    fn add_vnode<NM: NodeManager>(
         vnode_info: VirtualNodeInfo,
+        vertices: &mut Vec<Vertex<NM>>,
         vnode_map: &mut NodeIDMap,
         known_node_ids: &HashSet<NodeID>,
         max_node_id_in_nodes: &mut usize,
@@ -149,6 +148,7 @@ impl ASABRContactPlan {
         }
 
         vnode_map.insert(vnode_info.vid, vnode_info.rids);
+        vertices.push(Vertex::VNode(vnode_info.vid));
 
         Ok(())
     }
@@ -186,7 +186,7 @@ impl ASABRContactPlan {
         contact_marker_map: Option<&StaticMarkerMap<CM>>,
     ) -> Result<ContactPlan<NM, CM>, String> {
         let mut contacts: Vec<Contact<NM, CM>> = Vec::new();
-        let mut nodes: Vec<Node<NM>> = Vec::new();
+        let mut vertices: Vec<Vertex<NM>> = Vec::new();
         let mut vnode_map: NodeIDMap = NodeIDMap::new();
 
         // These include nodes and vnodes
@@ -233,7 +233,7 @@ impl ASABRContactPlan {
                             }
                         }
                     }
-                    "node" => {
+                    "node" | "enode" => {
                         let node = parse_components::<NodeInfo, NM>(lexer, node_marker_map);
                         match node {
                             ParsingState::EOF => {
@@ -251,12 +251,17 @@ impl ASABRContactPlan {
                                 };
 
                                 Self::add_node(
-                                    node,
-                                    &mut nodes,
+                                    &node,
                                     &mut max_node_id_in_nodes,
                                     &mut known_node_ids,
                                     &mut known_node_names,
                                 )?;
+
+                                match element_type.as_str() {
+                                    "node" => vertices.push(Vertex::INode(node)),
+                                    "enode" => vertices.push(Vertex::ENode(node)),
+                                    _ => unreachable!(),
+                                };
                             }
                         }
                     }
@@ -269,38 +274,10 @@ impl ASABRContactPlan {
                             ParsingState::Error(msg) => {
                                 return Err(msg);
                             }
-                            ParsingState::Finished((info, manager)) => {
-                                // A vnode is not only a mapping to a list of NodeIDs in a vnode_map, it is also a real node in the graph.
-                                // Thus here we instantiate a Node object from the VirtualNodeInfo
-                                let node_info = NodeInfo {
-                                    id: info.vid,
-                                    name: info.name.clone(),
-                                    excluded: false,
-                                };
-
-                                let Some(vnode) = Node::try_new(node_info, manager) else {
-                                    return Err(format!(
-                                        "Malformed node ({})",
-                                        lexer.get_current_position()
-                                    ));
-                                };
-
-                                // Add the vnode to the nodes list, returning on error.
-                                // This also updates max_node_id_in_nodes, known_node_ids and
-                                // known_node_names.
-                                Self::add_node(
-                                    vnode,
-                                    &mut nodes,
-                                    &mut max_node_id_in_nodes,
-                                    &mut known_node_ids,
-                                    &mut known_node_names,
-                                )?;
-
-                                // Add the vnode to the vnode_map, returning on error.
-                                // add_vnode must come after add_node, as it relies on previous
-                                // checks and updates to the nodes list.
+                            ParsingState::Finished((info, _)) => {
                                 Self::add_vnode(
                                     info,
+                                    &mut vertices,
                                     &mut vnode_map,
                                     &known_node_ids,
                                     &mut max_node_id_in_nodes,
@@ -323,14 +300,14 @@ impl ASABRContactPlan {
                     .to_string(),
             );
         }
-        if nodes.is_empty() {
+        if vertices.is_empty() {
             return Err("Nodes must be declared".to_string());
         }
-        if nodes.len() - 1 != max_node_id_in_nodes {
+        if vertices.len() - 1 != max_node_id_in_nodes {
             return Err("Some node declarations are missing".to_string());
         }
 
-        ContactPlan::new(nodes, contacts, Some(VirtualNodeMap::new(vnode_map)))
+        ContactPlan::new(vertices, contacts, Some(VirtualNodeMap::new(vnode_map)))
             .map_err(|_| "Failed to create contact plan".to_string())
     }
 }

--- a/src/contact_plan/from_ion_file.rs
+++ b/src/contact_plan/from_ion_file.rs
@@ -67,7 +67,7 @@ fn contact_info_from_tvg_data(data: &IONContactData) -> ContactInfo {
 }
 
 pub trait FromIONContactData<NM: NodeManager, CM: ContactManager> {
-    fn ion_convert(data: &IONContactData) -> Option<Contact<NM, CM>>;
+    fn ion_convert(data: &IONContactData) -> Option<Contact<NoManagement, CM>>;
 }
 
 macro_rules! generate_for_evl_variants {
@@ -165,7 +165,7 @@ fn get_confidence(vec: &[String]) -> f32 {
 impl IONContactPlan {
     pub fn parse<NM: NodeManager, CM: FromIONContactData<NM, CM> + ContactManager>(
         filename: &str,
-    ) -> io::Result<ContactPlan<NoManagement, NM, CM>> {
+    ) -> io::Result<ContactPlan<NoManagement, CM>> {
         let file = File::open(filename)?;
         let mut reader = BufReader::new(file);
         let mut map_id_map: HashMap<String, NodeID> = HashMap::new();

--- a/src/contact_plan/from_ion_file.rs
+++ b/src/contact_plan/from_ion_file.rs
@@ -25,8 +25,8 @@ use std::{
 pub struct IONContactData {
     tx_start: Date,
     tx_end: Date,
-    tx_node: NodeID,
-    rx_node: NodeID,
+    tx_node_id: NodeID,
+    rx_node_id: NodeID,
     data_rate: DataRate,
     delay: Duration,
     _confidence: f32,
@@ -57,13 +57,13 @@ impl Eq for IONContactData {}
 struct IONRangeData {
     tx_start: Date,
     tx_end: Date,
-    tx_node: NodeID,
-    rx_node: NodeID,
+    tx_node_id: NodeID,
+    rx_node_id: NodeID,
     delay: Duration,
 }
 
 fn contact_info_from_tvg_data(data: &IONContactData) -> ContactInfo {
-    ContactInfo::new(data.tx_node, data.rx_node, data.tx_start, data.tx_end)
+    ContactInfo::new(data.tx_node_id, data.rx_node_id, data.tx_start, data.tx_end)
 }
 
 pub trait FromIONContactData<NM: NodeManager, CM: ContactManager> {
@@ -139,18 +139,18 @@ fn manage_contacts(
     contact_map: &mut HashMap<NodeID, HashMap<NodeID, Vec<IONContactData>>>,
     contact: IONContactData,
 ) {
-    let tx_node = contact.tx_node;
-    let rx_node = contact.rx_node;
+    let tx_node_id = contact.tx_node_id;
+    let rx_node_id = contact.rx_node_id;
 
-    if let Some(inner_map) = contact_map.get_mut(&tx_node) {
+    if let Some(inner_map) = contact_map.get_mut(&tx_node_id) {
         inner_map
-            .entry(rx_node)
+            .entry(rx_node_id)
             .or_insert_with(Vec::new)
             .push(contact);
     } else {
         let mut inner_map = HashMap::new();
-        inner_map.insert(rx_node, vec![contact]);
-        contact_map.insert(tx_node, inner_map);
+        inner_map.insert(rx_node_id, vec![contact]);
+        contact_map.insert(tx_node_id, inner_map);
     }
 }
 
@@ -201,8 +201,8 @@ impl IONContactPlan {
             if words[1].as_str() == "contact" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
-                let tx_node = manage_aliases(&mut map_id_map, &words[4], &mut nodes);
-                let rx_node = manage_aliases(&mut map_id_map, &words[5], &mut nodes);
+                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut nodes);
+                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut nodes);
                 let data_rate: DataRate = words[6].parse().unwrap();
                 let confidence = get_confidence(&words);
                 contact_count += 1;
@@ -212,8 +212,8 @@ impl IONContactPlan {
                     IONContactData {
                         tx_start,
                         tx_end,
-                        tx_node,
-                        rx_node,
+                        tx_node_id,
+                        rx_node_id,
                         data_rate,
                         delay: 0.0,
                         _confidence: confidence,
@@ -223,14 +223,14 @@ impl IONContactPlan {
             if words[1].as_str() == "range" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
-                let tx_node = manage_aliases(&mut map_id_map, &words[4], &mut nodes);
-                let rx_node = manage_aliases(&mut map_id_map, &words[5], &mut nodes);
+                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut nodes);
+                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut nodes);
                 let delay: Duration = words[6].parse().unwrap();
                 ranges.push(IONRangeData {
                     tx_start,
                     tx_end,
-                    tx_node,
-                    rx_node,
+                    tx_node_id,
+                    rx_node_id,
                     delay,
                 });
             }
@@ -244,8 +244,8 @@ impl IONContactPlan {
         }
 
         for range in &ranges {
-            if let Some(tx_map) = contact_info_map.get_mut(&range.tx_node)
-                && let Some(contact_vec) = tx_map.get_mut(&range.rx_node)
+            if let Some(tx_map) = contact_info_map.get_mut(&range.tx_node_id)
+                && let Some(contact_vec) = tx_map.get_mut(&range.rx_node_id)
             {
                 for contact in contact_vec.iter_mut() {
                     if range.tx_start <= contact.tx_start && contact.tx_end <= range.tx_end {

--- a/src/contact_plan/from_ion_file.rs
+++ b/src/contact_plan/from_ion_file.rs
@@ -14,6 +14,7 @@ use crate::{
     node::{Node, NodeInfo},
     node_manager::{NodeManager, none::NoManagement},
     types::{DataRate, Date, Duration, NodeID},
+    vertex::Vertex,
 };
 
 use std::{cmp::Ordering, collections::HashMap};
@@ -113,14 +114,14 @@ pub struct IONContactPlan {}
 fn manage_aliases(
     map_id_map: &mut HashMap<String, NodeID>,
     candidate_name: &String,
-    nodes: &mut Vec<Node<NoManagement>>,
+    vertices: &mut Vec<Vertex<NoManagement>>,
 ) -> NodeID {
     if let Some(value) = map_id_map.get(candidate_name) {
         *value
     } else {
         let next = map_id_map.len() as NodeID;
         map_id_map.insert(candidate_name.clone(), next);
-        nodes.push(
+        vertices.push(Vertex::INode(
             Node::try_new(
                 NodeInfo {
                     id: next as NodeID,
@@ -130,7 +131,7 @@ fn manage_aliases(
                 NoManagement {},
             )
             .unwrap(),
-        );
+        ));
         next
     }
 }
@@ -176,7 +177,7 @@ impl IONContactPlan {
 
         let mut contact_count = 0;
         let mut contacts = vec![];
-        let mut nodes = vec![];
+        let mut vertices = vec![];
 
         loop {
             let mut line = String::new();
@@ -201,8 +202,8 @@ impl IONContactPlan {
             if words[1].as_str() == "contact" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
-                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut nodes);
-                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut nodes);
+                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut vertices);
+                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut vertices);
                 let data_rate: DataRate = words[6].parse().unwrap();
                 let confidence = get_confidence(&words);
                 contact_count += 1;
@@ -223,8 +224,8 @@ impl IONContactPlan {
             if words[1].as_str() == "range" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
-                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut nodes);
-                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut nodes);
+                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut vertices);
+                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut vertices);
                 let delay: Duration = words[6].parse().unwrap();
                 ranges.push(IONRangeData {
                     tx_start,
@@ -266,6 +267,6 @@ impl IONContactPlan {
             ))?;
         }
 
-        Ok(ContactPlan::new(nodes, contacts, None)?)
+        Ok(ContactPlan::new(vertices, contacts, None)?)
     }
 }

--- a/src/contact_plan/from_tvgutil_file.rs
+++ b/src/contact_plan/from_tvgutil_file.rs
@@ -13,6 +13,7 @@ use crate::{
     node::{Node, NodeInfo},
     node_manager::{NodeManager, none::NoManagement},
     types::{DataRate, Date, Duration, NodeID},
+    vertex::Vertex,
 };
 
 use std::{collections::HashMap, io};
@@ -83,7 +84,7 @@ impl TVGUtilContactPlan {
     pub fn parse<NM: NodeManager, CM: FromTVGUtilContactData<NM, CM> + ContactManager>(
         filename: &str,
     ) -> io::Result<ContactPlan<NoManagement, CM>> {
-        let mut nodes: Vec<Node<NoManagement>> = Vec::new();
+        let mut vertices: Vec<Vertex<NoManagement>> = Vec::new();
         let mut contacts: Vec<Contact<NoManagement, CM>> = Vec::new();
 
         let mut map_id_map: HashMap<&str, NodeID> = HashMap::new();
@@ -94,7 +95,7 @@ impl TVGUtilContactPlan {
 
         for (node_id, (node_name, _node_data)) in json_nodes.iter().enumerate() {
             map_id_map.insert(node_name, node_id as NodeID);
-            nodes.push(
+            vertices.push(Vertex::ENode(
                 Node::try_new(
                     NodeInfo {
                         id: node_id as NodeID,
@@ -104,7 +105,7 @@ impl TVGUtilContactPlan {
                     NoManagement {},
                 )
                 .unwrap(),
-            );
+            ));
         }
 
         let json_contacts = parsed["edges"].as_array().unwrap();
@@ -141,6 +142,6 @@ impl TVGUtilContactPlan {
                 contacts.push(contact);
             }
         }
-        Ok(ContactPlan::new(nodes, contacts, None)?)
+        Ok(ContactPlan::new(vertices, contacts, None)?)
     }
 }

--- a/src/contact_plan/from_tvgutil_file.rs
+++ b/src/contact_plan/from_tvgutil_file.rs
@@ -36,7 +36,7 @@ fn contact_info_from_tvg_data(data: &TVGUtilContactData) -> ContactInfo {
 }
 
 pub trait FromTVGUtilContactData<NM: NodeManager, CM: ContactManager> {
-    fn tvg_convert(data: TVGUtilContactData) -> Option<Contact<NM, CM>>;
+    fn tvg_convert(data: TVGUtilContactData) -> Option<Contact<NoManagement, CM>>;
 }
 
 macro_rules! generate_for_evl_variants {
@@ -82,9 +82,9 @@ pub struct TVGUtilContactPlan {}
 impl TVGUtilContactPlan {
     pub fn parse<NM: NodeManager, CM: FromTVGUtilContactData<NM, CM> + ContactManager>(
         filename: &str,
-    ) -> io::Result<ContactPlan<NoManagement, NM, CM>> {
+    ) -> io::Result<ContactPlan<NoManagement, CM>> {
         let mut nodes: Vec<Node<NoManagement>> = Vec::new();
-        let mut contacts: Vec<Contact<NM, CM>> = Vec::new();
+        let mut contacts: Vec<Contact<NoManagement, CM>> = Vec::new();
 
         let mut map_id_map: HashMap<&str, NodeID> = HashMap::new();
 

--- a/src/contact_plan/from_tvgutil_file.rs
+++ b/src/contact_plan/from_tvgutil_file.rs
@@ -24,15 +24,15 @@ use std::fs;
 pub struct TVGUtilContactData {
     tx_start: Date,
     tx_end: Date,
-    tx_node: NodeID,
-    rx_node: NodeID,
+    tx_node_id: NodeID,
+    rx_node_id: NodeID,
     delay: Duration,
     data_rate: DataRate,
     _confidence: f32,
 }
 
 fn contact_info_from_tvg_data(data: &TVGUtilContactData) -> ContactInfo {
-    ContactInfo::new(data.tx_node, data.rx_node, data.tx_start, data.tx_end)
+    ContactInfo::new(data.tx_node_id, data.rx_node_id, data.tx_start, data.tx_end)
 }
 
 pub trait FromTVGUtilContactData<NM: NodeManager, CM: ContactManager> {
@@ -111,8 +111,8 @@ impl TVGUtilContactPlan {
         for nodes_pair in json_contacts {
             let data = nodes_pair.as_object().unwrap();
             let pair = data["vertices"].as_array().unwrap();
-            let tx_node = map_id_map.get(pair[0].as_str().unwrap()).unwrap();
-            let rx_node = map_id_map.get(pair[1].as_str().unwrap()).unwrap();
+            let tx_node_id = map_id_map.get(pair[0].as_str().unwrap()).unwrap();
+            let rx_node_id = map_id_map.get(pair[1].as_str().unwrap()).unwrap();
 
             for contact_data in data["contacts"].as_array().unwrap() {
                 let contact_array = contact_data.as_array().unwrap();
@@ -129,8 +129,8 @@ impl TVGUtilContactPlan {
                 let tvgcontact = TVGUtilContactData {
                     tx_start: start,
                     tx_end: end,
-                    tx_node: *tx_node,
-                    rx_node: *rx_node,
+                    tx_node_id: *tx_node_id,
+                    rx_node_id: *rx_node_id,
                     delay,
                     data_rate,
                     _confidence: confidence,

--- a/src/contact_plan/mod.rs
+++ b/src/contact_plan/mod.rs
@@ -3,7 +3,7 @@ use crate::contact_manager::ContactManager;
 use crate::errors::ASABRError;
 use crate::node::Node;
 use crate::node_manager::NodeManager;
-use crate::types::VirtualNodeMap;
+use crate::vnode::VirtualNodeMap;
 
 pub mod asabr_file_lexer;
 pub mod from_asabr_lexer;

--- a/src/contact_plan/mod.rs
+++ b/src/contact_plan/mod.rs
@@ -1,8 +1,8 @@
 use crate::contact::Contact;
 use crate::contact_manager::ContactManager;
 use crate::errors::ASABRError;
-use crate::node::Node;
 use crate::node_manager::NodeManager;
+use crate::vertex::Vertex;
 use crate::vnode::VirtualNodeMap;
 
 pub mod asabr_file_lexer;
@@ -18,8 +18,10 @@ pub mod from_tvgutil_file;
 /// - `CCM`: A type implementing the `ContactManager` trait, responsible for managing the
 ///   contact's operations.
 pub struct ContactPlan<NM: NodeManager, CM: ContactManager> {
-    pub nodes: Vec<Node<NM>>,
+    /// Vertices sorted by ID. All `VNode`s come after every `INode`s and `ENode`s.
+    pub vertices: Vec<Vertex<NM>>,
     pub contacts: Vec<Contact<NM, CM>>,
+    /// Maps vnodes and the nodes they label.
     pub vnode_map: VirtualNodeMap,
 }
 
@@ -36,12 +38,12 @@ impl<NM: NodeManager, CM: ContactManager> ContactPlan<NM, CM> {
     ///
     /// * `Self` - A new instance of `ContactPlan`.
     pub fn new(
-        nodes: Vec<Node<NM>>,
+        vertices: Vec<Vertex<NM>>,
         contacts: Vec<Contact<NM, CM>>,
         vnode_map: Option<VirtualNodeMap>,
     ) -> Result<Self, ASABRError> {
         Ok(ContactPlan {
-            nodes,
+            vertices,
             contacts,
             vnode_map: vnode_map.unwrap_or_default(),
         })

--- a/src/contact_plan/mod.rs
+++ b/src/contact_plan/mod.rs
@@ -17,13 +17,13 @@ pub mod from_tvgutil_file;
 ///   node's operations.
 /// - `CCM`: A type implementing the `ContactManager` trait, responsible for managing the
 ///   contact's operations.
-pub struct ContactPlan<NNM: NodeManager, CNM: NodeManager, CCM: ContactManager> {
-    pub nodes: Vec<Node<NNM>>,
-    pub contacts: Vec<Contact<CNM, CCM>>,
+pub struct ContactPlan<NM: NodeManager, CM: ContactManager> {
+    pub nodes: Vec<Node<NM>>,
+    pub contacts: Vec<Contact<NM, CM>>,
     pub vnode_map: VirtualNodeMap,
 }
 
-impl<NNM: NodeManager, CNM: NodeManager, CCM: ContactManager> ContactPlan<NNM, CNM, CCM> {
+impl<NM: NodeManager, CM: ContactManager> ContactPlan<NM, CM> {
     /// Creates a new `ContactPlan`.
     ///
     /// # Parameters
@@ -36,8 +36,8 @@ impl<NNM: NodeManager, CNM: NodeManager, CCM: ContactManager> ContactPlan<NNM, C
     ///
     /// * `Self` - A new instance of `ContactPlan`.
     pub fn new(
-        nodes: Vec<Node<NNM>>,
-        contacts: Vec<Contact<CNM, CCM>>,
+        nodes: Vec<Node<NM>>,
+        contacts: Vec<Contact<NM, CM>>,
         vnode_map: Option<VirtualNodeMap>,
     ) -> Result<Self, ASABRError> {
         Ok(ContactPlan {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use std::cell::BorrowMutError;
+use std::cell::{BorrowError, BorrowMutError};
 use std::error::Error;
 use std::fmt;
 
@@ -11,9 +11,15 @@ pub enum ASABRError {
     MulticastUnsupportedError,
 }
 
+impl From<BorrowError> for ASABRError {
+    fn from(_: BorrowError) -> Self {
+        ASABRError::BorrowMutError("borrow error occurred")
+    }
+}
+
 impl From<BorrowMutError> for ASABRError {
     fn from(_: BorrowMutError) -> Self {
-        ASABRError::BorrowMutError("borrow error occurred")
+        ASABRError::BorrowMutError("mutable borrow error occurred")
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,6 +9,7 @@ pub enum ASABRError {
     ScheduleError(&'static str),
     ContactPlanError(&'static str),
     MulticastUnsupportedError,
+    ParsingError(String),
 }
 
 impl From<BorrowError> for ASABRError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod node;
 pub mod node_manager;
 /// Module containing the library primitive types.
 pub mod types;
+/// Module containing the vertex definition.
+pub mod vertex;
 /// Module containing the vnode definition.
 pub mod vnode;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,13 @@ fn main() -> Result<(), ASABRError> {
         &mut mylexer,
         None,
         Some(&contact_dispatch),
-    )?;
+    )
+    .map_err(|e| match e {
+        ASABRError::ParsingError(e) => ASABRError::ParsingError(
+            format!("<cp_file> must be in ASABR format with NoManagement for nodes and dynamic management (evl, qd, eto or seg) for contacts. Error while parsing CP: {e}"),
+        ),
+        _ => e,
+    })?;
 
     // We create a storage for the Paths
     let table = Rc::new(RefCell::new(TreeCache::new(true, false, 10)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,7 @@ fn main() -> Result<(), ASABRError> {
         &mut mylexer,
         None,
         Some(&contact_dispatch),
-    )
-    .unwrap();
+    )?;
 
     // We create a storage for the Paths
     let table = Rc::new(RefCell::new(TreeCache::new(true, false, 10)));

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -8,7 +8,7 @@ use crate::contact_plan::ContactPlan;
 use crate::errors::ASABRError;
 use crate::node_manager::NodeManager;
 use crate::types::*;
-use crate::vertex::VertexID;
+use crate::vertex::{Vertex, VertexID};
 
 /// Represents a sender node in a routing system, with associated receivers.
 ///
@@ -114,7 +114,14 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
     ///
     /// * `Self` - A new instance of `Multigraph`.
     pub fn new(contact_plan: ContactPlan<NM, CM>) -> Result<Self, ASABRError> {
-        let mut nodes = contact_plan.nodes;
+        let mut nodes: Vec<Node<NM>> = contact_plan
+            .vertices
+            .into_iter()
+            .filter_map(|v| match v {
+                Vertex::INode(node) => Some(node),
+                _ => None,
+            })
+            .collect();
         let mut contacts = contact_plan.contacts;
 
         let node_count = nodes.len();

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -116,6 +116,7 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
     /// * `Self` - A new instance of `Multigraph`.
     pub fn new(contact_plan: ContactPlan<NM, CM>) -> Result<Self, ASABRError> {
         // work area
+        let vnodes_for_rid = contact_plan.vnode_map.get_rid_to_vnodes_map();
         let vertex_count = contact_plan.vertices.len();
         let virtual_node_count = contact_plan.vnode_map.get_vnode_to_rids_map().len();
         let real_node_count = vertex_count - virtual_node_count;
@@ -125,7 +126,7 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
             VertexID,
             HashMap<VertexID, Vec<Rc<RefCell<Contact<NM, CM>>>>>,
         > = HashMap::with_capacity(vertex_count);
-        let mut is_interior = vec![false; real_node_count];
+        let mut is_external = vec![false; vertex_count];
 
         // output
         let mut nodes = Vec::with_capacity(real_node_count);
@@ -133,29 +134,29 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
 
         // collect real nodes, track enodes, init senders
         for ver in contact_plan.vertices {
-            if let Vertex::INode(node) = &ver {
-                is_interior[node.get_node_id() as usize] = true;
+            if let Vertex::ENode(node) = &ver {
+                is_external[node.get_node_id() as usize] = true;
             }
 
-            match ver {
-                Vertex::ENode(node) | Vertex::INode(node) => {
+            let vertex_id = match ver {
+                Vertex::ENode(node) => {
                     let id = node.get_node_id();
                     nodes.push(Rc::new(RefCell::new(node)));
-                    senders.push(Sender {
-                        vertex_id: id,
-                        receivers: Vec::with_capacity(vertex_count),
-                    });
+                    id
                 }
-                Vertex::VNode(vid) => {
-                    senders.push(Sender {
-                        vertex_id: vid,
-                        receivers: Vec::with_capacity(vertex_count),
-                    });
+                Vertex::INode(node) => {
+                    let id = node.get_node_id();
+                    nodes.push(Rc::new(RefCell::new(node)));
+                    id
                 }
-            }
-        }
 
-        let vnodes_for_rid = contact_plan.vnode_map.get_rid_to_vnodes_map();
+                Vertex::VNode(vid) => vid,
+            };
+            senders.push(Sender {
+                vertex_id,
+                receivers: Vec::with_capacity(vertex_count),
+            });
+        }
 
         // Fill contacts into vertex Sender and Receiver pairs (including vnodes) in the map.
         for contact in contact_plan.contacts {
@@ -176,12 +177,15 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
                     .flatten()
                     .chain(std::iter::once(&real_rx_id))
                 {
-                    snd_rcv_map
-                        .entry(*t)
-                        .or_default()
-                        .entry(*r)
-                        .or_default()
-                        .push(contact_rc.clone());
+                    // Only add inodes and vnodes as Sender/Receiver in the graph
+                    if !is_external[*t as usize] && !is_external[*r as usize] {
+                        snd_rcv_map
+                            .entry(*t)
+                            .or_default()
+                            .entry(*r)
+                            .or_default()
+                            .push(contact_rc.clone());
+                    }
                 }
             }
         }

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use super::node::Node;
@@ -91,10 +92,10 @@ impl<NM: NodeManager, CM: ContactManager> Receiver<NM, CM> {
 pub struct Multigraph<NM: NodeManager, CM: ContactManager> {
     /// The list of sender objects.
     pub senders: Vec<Sender<NM, CM>>,
-    /// * `nodes` - The list of node objects.
-    pub nodes: Vec<Rc<RefCell<Node<NM>>>>,
-    /// * `node_count` - The total number of nodes in the multigraph.
-    node_count: usize,
+    /// The list of node objects.
+    pub real_nodes: Vec<Rc<RefCell<Node<NM>>>>,
+    /// The total number of nodes in the multigraph.
+    vertex_count: usize,
 }
 
 impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
@@ -114,82 +115,101 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
     ///
     /// * `Self` - A new instance of `Multigraph`.
     pub fn new(contact_plan: ContactPlan<NM, CM>) -> Result<Self, ASABRError> {
-        let mut nodes: Vec<Node<NM>> = contact_plan
-            .vertices
-            .into_iter()
-            .filter_map(|v| match v {
-                Vertex::INode(node) => Some(node),
-                _ => None,
-            })
-            .collect();
-        let mut contacts = contact_plan.contacts;
+        // work area
+        let vertex_count = contact_plan.vertices.len();
+        let virtual_node_count = contact_plan.vnode_map.get_vnode_to_rids_map().len();
+        let real_node_count = vertex_count - virtual_node_count;
+        #[allow(clippy::type_complexity)]
+        // Maps contacts to Sender vertex IDs and Receiver vertex IDs.
+        let mut snd_rcv_map: HashMap<
+            VertexID,
+            HashMap<VertexID, Vec<Rc<RefCell<Contact<NM, CM>>>>>,
+        > = HashMap::with_capacity(vertex_count);
+        let mut is_interior = vec![false; real_node_count];
 
-        let node_count = nodes.len();
-        let mut senders: Vec<Sender<NM, CM>> = Vec::with_capacity(node_count);
+        // output
+        let mut nodes = Vec::with_capacity(real_node_count);
+        let mut senders = Vec::with_capacity(vertex_count);
 
-        // the contacts might not be sorted
-        // having a sorted list of contacts allow easy multigraph creation
-        contacts.sort_unstable();
-        nodes.sort_unstable();
+        // collect real nodes, track enodes, init senders
+        for ver in contact_plan.vertices {
+            if let Vertex::INode(node) = &ver {
+                is_interior[node.get_node_id() as usize] = true;
+            }
 
-        let mut all_refs = Vec::with_capacity(node_count);
-
-        // Create the `Sender` of each node, and populate node refs in all_refs.
-        for node in nodes {
-            let node_ref = Rc::new(RefCell::new(node));
-            senders.push(Sender {
-                vertex_id: node_ref.try_borrow()?.get_node_id(),
-                // to avoid realloc and preprocessing to get the perfect layout
-                // we just alloc with the worst case capacity and we shrink later
-                receivers: Vec::with_capacity(node_count),
-            });
-            all_refs.push(node_ref)
-        }
-
-        // The following creates the `Sender`/`Receiver`s pairs from every contact.
-        // Contacts are sorted and iterated over in reverse.
-        while let Some(last_contact) = contacts.last() {
-            let tx_id = last_contact.get_tx_node_id();
-            let rx_id = last_contact.get_rx_node_id();
-
-            // Count how many contacts have the same Tx and Rx nodes as `last_contact`.
-            // There should be at least one (`last_contact` itself).
-            let mut contact_count_to_drain = 0;
-
-            for contact in contacts.iter().rev() {
-                if contact.get_rx_node_id() != rx_id as NodeID
-                    || contact.get_tx_node_id() != tx_id as NodeID
-                {
-                    break;
+            match ver {
+                Vertex::ENode(node) | Vertex::INode(node) => {
+                    let id = node.get_node_id();
+                    nodes.push(Rc::new(RefCell::new(node)));
+                    senders.push(Sender {
+                        vertex_id: id,
+                        receivers: Vec::with_capacity(vertex_count),
+                    });
                 }
-                contact_count_to_drain += 1;
+                Vertex::VNode(vid) => {
+                    senders.push(Sender {
+                        vertex_id: vid,
+                        receivers: Vec::with_capacity(vertex_count),
+                    });
+                }
             }
-
-            // Transfer said contact·s from `contacts` to `contacts_to_receiver`.
-            let mut contacts_to_receiver = Vec::with_capacity(contact_count_to_drain);
-            let first_to_drain = contacts.len() - contact_count_to_drain;
-            let drain = contacts.drain(first_to_drain..);
-
-            for contact in drain {
-                contacts_to_receiver.push(Rc::new(RefCell::new(contact)));
-            }
-
-            // Transfer to `Sender`/`Receiver`s pair.
-            senders[tx_id as usize].receivers.push(Receiver {
-                vertex_id: rx_id,
-                contacts_to_receiver,
-                next: RefCell::new(0),
-            });
         }
 
-        for sender in &mut senders {
-            sender.receivers.shrink_to_fit();
+        let vnodes_for_rid = contact_plan.vnode_map.get_rid_to_vnodes_map();
+
+        // Fill contacts into vertex Sender and Receiver pairs (including vnodes) in the map.
+        for contact in contact_plan.contacts {
+            let real_tx_id = contact.get_tx_node_id();
+            let real_rx_id = contact.get_rx_node_id();
+
+            let contact_rc = Rc::new(RefCell::new(contact));
+
+            for t in vnodes_for_rid
+                .get(&real_tx_id)
+                .into_iter()
+                .flatten()
+                .chain(std::iter::once(&real_tx_id))
+            {
+                for r in vnodes_for_rid
+                    .get(&real_rx_id)
+                    .into_iter()
+                    .flatten()
+                    .chain(std::iter::once(&real_rx_id))
+                {
+                    snd_rcv_map
+                        .entry(*t)
+                        .or_default()
+                        .entry(*r)
+                        .or_default()
+                        .push(contact_rc.clone());
+                }
+            }
+        }
+
+        // now "flatten" (move to linear data structure) and shrink receivers
+        for (t, receivers) in snd_rcv_map {
+            for (r, mut contacts) in receivers {
+                if (t as usize) < real_node_count && (r as usize) < real_node_count {
+                    contacts.sort_unstable();
+                } else {
+                    // A vnode Sender or Receiver's contacts must be sorted by time only, not by
+                    // Tx/Rx node ID.
+                    contacts.sort_unstable_by(|a, b| a.borrow().cmp_by_start(&b.borrow()))
+                }
+                let recver = Receiver {
+                    vertex_id: r,
+                    contacts_to_receiver: contacts,
+                    next: 0.into(),
+                };
+                senders[t as usize].receivers.push(recver);
+            }
+            senders[t as usize].receivers.shrink_to_fit();
         }
 
         Ok(Self {
             senders,
-            nodes: all_refs,
-            node_count,
+            real_nodes: nodes,
+            vertex_count,
         })
     }
 
@@ -211,7 +231,7 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
         let mut exclusion_idx = 0;
         let exclusion_len = exclusions.len();
 
-        for (node_id, node) in self.nodes.iter_mut().enumerate() {
+        for (node_id, node) in self.real_nodes.iter_mut().enumerate() {
             if exclusion_idx < exclusion_len && exclusions[exclusion_idx] as usize == node_id {
                 node.try_borrow_mut()?.info.excluded = true;
                 exclusion_idx += 1;
@@ -222,12 +242,12 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
         Ok(())
     }
 
-    /// Retrieves the total number of nodes in the multigraph.
+    /// Retrieves the total number of vertices in the multigraph.
     ///
     /// # Returns
     ///
-    /// * `usize` - The total number of nodes.
-    pub fn get_node_count(&self) -> usize {
-        self.node_count
+    /// * `usize` - The total number of vertices.
+    pub fn get_vertex_count(&self) -> usize {
+        self.vertex_count
     }
 }

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -136,16 +136,16 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
         // The following creates the `Sender`/`Receiver`s pairs from every contact.
         // Contacts are sorted and iterated over in reverse.
         while let Some(last_contact) = contacts.last() {
-            let tx_id = last_contact.get_tx_node();
-            let rx_id = last_contact.get_rx_node();
+            let tx_id = last_contact.get_tx_node_id();
+            let rx_id = last_contact.get_rx_node_id();
 
             // Count how many contacts have the same Tx and Rx nodes as `last_contact`.
             // There should be at least one (`last_contact` itself).
             let mut contact_count_to_drain = 0;
 
             for contact in contacts.iter().rev() {
-                if contact.get_rx_node() != rx_id as NodeID
-                    || contact.get_tx_node() != tx_id as NodeID
+                if contact.get_rx_node_id() != rx_id as NodeID
+                    || contact.get_tx_node_id() != tx_id as NodeID
                 {
                     break;
                 }

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -107,7 +107,7 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
     /// # Returns
     ///
     /// * `Self` - A new instance of `Multigraph`.
-    pub fn new(contact_plan: ContactPlan<NM, NM, CM>) -> Result<Self, ASABRError> {
+    pub fn new(contact_plan: ContactPlan<NM, CM>) -> Result<Self, ASABRError> {
         let mut nodes = contact_plan.nodes;
         let mut contacts = contact_plan.contacts;
         // the contacts might not be sorted

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -40,7 +40,7 @@ pub struct Receiver<NM: NodeManager, CM: ContactManager> {
     /// A list of contacts providing paths to this receiver.
     pub contacts_to_receiver: Vec<Rc<RefCell<Contact<NM, CM>>>>,
     /// The index of the next contact to be checked for relevance.
-    pub next: usize,
+    pub next: RefCell<usize>,
 }
 
 impl<NM: NodeManager, CM: ContactManager> Receiver<NM, CM> {
@@ -56,10 +56,11 @@ impl<NM: NodeManager, CM: ContactManager> Receiver<NM, CM> {
     /// # Returns
     /// - `Some(usize)`: The index of the first valid contact if found.
     /// - `None`: If no valid contact is found.
-    pub fn lazy_prune_and_get_first_idx(&mut self, current_time: Date) -> Option<usize> {
-        for (idx, contact) in self.contacts_to_receiver.iter().enumerate().skip(self.next) {
+    pub fn lazy_prune_and_get_first_idx(&self, current_time: Date) -> Option<usize> {
+        let mut next_mut = self.next.borrow_mut();
+        for (idx, contact) in self.contacts_to_receiver.iter().enumerate().skip(*next_mut) {
             if contact.borrow().info.end > current_time {
-                self.next = idx;
+                *next_mut = idx;
                 return Some(idx);
             }
         }
@@ -164,7 +165,7 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
             senders[tx_id as usize].receivers.push(Receiver {
                 node: all_refs[rx_id as usize].clone(),
                 contacts_to_receiver,
-                next: 0,
+                next: RefCell::new(0),
             });
         }
 

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -110,11 +110,12 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
     pub fn new(contact_plan: ContactPlan<NM, CM>) -> Result<Self, ASABRError> {
         let mut nodes = contact_plan.nodes;
         let mut contacts = contact_plan.contacts;
-        // the contacts might not be sorted
-        // having a sorted list of contacts allow easy multigraph creation
+
         let node_count = nodes.len();
         let mut senders: Vec<Sender<NM, CM>> = Vec::with_capacity(node_count);
 
+        // the contacts might not be sorted
+        // having a sorted list of contacts allow easy multigraph creation
         contacts.sort_unstable();
         nodes.sort_unstable();
 
@@ -131,10 +132,14 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
             all_refs.push(node_ref)
         }
 
+        // The following creates the `Sender`/`Receiver`s pairs from every contact.
+        // Contacts are sorted and iterated over in reverse.
         while let Some(last_contact) = contacts.last() {
             let tx_id = last_contact.get_tx_node();
             let rx_id = last_contact.get_rx_node();
 
+            // Count how many contacts have the same Tx and Rx nodes as `last_contact`.
+            // There should be at least one (`last_contact` itself).
             let mut contact_count_to_drain = 0;
 
             for contact in contacts.iter().rev() {
@@ -146,14 +151,16 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
                 contact_count_to_drain += 1;
             }
 
-            let first_to_drain = contacts.len() - contact_count_to_drain;
+            // Transfer said contact·s from `contacts` to `contacts_to_receiver`.
             let mut contacts_to_receiver = Vec::with_capacity(contact_count_to_drain);
+            let first_to_drain = contacts.len() - contact_count_to_drain;
             let drain = contacts.drain(first_to_drain..);
 
             for contact in drain {
                 contacts_to_receiver.push(Rc::new(RefCell::new(contact)));
             }
 
+            // Transfer to `Sender`/`Receiver`s pair.
             senders[tx_id as usize].receivers.push(Receiver {
                 node: all_refs[rx_id as usize].clone(),
                 contacts_to_receiver,

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -204,18 +204,12 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
         let mut exclusion_idx = 0;
         let exclusion_len = exclusions.len();
 
-        for (node_id, sender) in self.senders.iter_mut().enumerate() {
+        for (node_id, node) in self.nodes.iter_mut().enumerate() {
             if exclusion_idx < exclusion_len && exclusions[exclusion_idx] as usize == node_id {
-                self.nodes[sender.vertex_id as usize]
-                    .try_borrow_mut()?
-                    .info
-                    .excluded = true;
+                node.try_borrow_mut()?.info.excluded = true;
                 exclusion_idx += 1;
             } else {
-                self.nodes[sender.vertex_id as usize]
-                    .try_borrow_mut()?
-                    .info
-                    .excluded = false;
+                node.try_borrow_mut()?.info.excluded = false;
             }
         }
         Ok(())

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -8,10 +8,11 @@ use crate::contact_plan::ContactPlan;
 use crate::errors::ASABRError;
 use crate::node_manager::NodeManager;
 use crate::types::*;
+use crate::vertex::VertexID;
 
 /// Represents a sender node in a routing system, with associated receivers.
 ///
-/// The `Sender` struct holds a reference to a sender node and a list of `Receiver`
+/// The `Sender` struct holds the ID of a sender vertex and a list of `Receiver`
 /// instances that represent the intended recipients for messages or routing actions.
 ///
 /// # Generic Parameters
@@ -19,8 +20,8 @@ use crate::types::*;
 /// - `CM`: A type implementing the `ContactManager` trait, responsible for managing contact-level operations.
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Sender<NM: NodeManager, CM: ContactManager> {
-    /// The node represented by this sender, wrapped in `Rc<RefCell<...>>` for shared ownership and mutability.
-    pub node: Rc<RefCell<Node<NM>>>,
+    /// The ID of the vertex represented by this sender.
+    pub vertex_id: VertexID,
     /// A list of receivers that this sender can communicate with or send data to.
     pub receivers: Vec<Receiver<NM, CM>>,
 }
@@ -35,8 +36,8 @@ pub struct Sender<NM: NodeManager, CM: ContactManager> {
 /// - `CM`: A type implementing the `ContactManager` trait, managing contact-level operations.
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Receiver<NM: NodeManager, CM: ContactManager> {
-    /// The node represented by this receiver, wrapped in `Rc<RefCell<...>>`.
-    pub node: Rc<RefCell<Node<NM>>>,
+    /// The ID of the vertex represented by this receiver.
+    pub vertex_id: VertexID,
     /// A list of contacts providing paths to this receiver.
     pub contacts_to_receiver: Vec<Rc<RefCell<Contact<NM, CM>>>>,
     /// The index of the next contact to be checked for relevance.
@@ -76,8 +77,12 @@ impl<NM: NodeManager, CM: ContactManager> Receiver<NM, CM> {
     /// # Returns
     /// - `true`: If the receiver node is excluded.
     /// - `false`: If the receiver node is included.
-    pub fn is_excluded(&self) -> bool {
-        return self.node.borrow().info.excluded;
+    pub fn is_excluded(&self, nodes: &[Rc<RefCell<Node<NM>>>]) -> bool {
+        if self.vertex_id as usize >= nodes.len() {
+            // It's a vnode
+            return false;
+        }
+        return nodes[self.vertex_id as usize].borrow().info.excluded;
     }
 }
 
@@ -122,12 +127,13 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
 
         let mut all_refs = Vec::with_capacity(node_count);
 
+        // Create the `Sender` of each node, and populate node refs in all_refs.
         for node in nodes {
             let node_ref = Rc::new(RefCell::new(node));
-            // to avoid realloc and preprocessing to get the perfect layout
-            // we just alloc with the worst case capacity and we shrink later
             senders.push(Sender {
-                node: Rc::clone(&node_ref),
+                vertex_id: node_ref.try_borrow()?.get_node_id(),
+                // to avoid realloc and preprocessing to get the perfect layout
+                // we just alloc with the worst case capacity and we shrink later
                 receivers: Vec::with_capacity(node_count),
             });
             all_refs.push(node_ref)
@@ -163,7 +169,7 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
 
             // Transfer to `Sender`/`Receiver`s pair.
             senders[tx_id as usize].receivers.push(Receiver {
-                node: all_refs[rx_id as usize].clone(),
+                vertex_id: rx_id,
                 contacts_to_receiver,
                 next: RefCell::new(0),
             });
@@ -200,10 +206,16 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
 
         for (node_id, sender) in self.senders.iter_mut().enumerate() {
             if exclusion_idx < exclusion_len && exclusions[exclusion_idx] as usize == node_id {
-                sender.node.try_borrow_mut()?.info.excluded = true;
+                self.nodes[sender.vertex_id as usize]
+                    .try_borrow_mut()?
+                    .info
+                    .excluded = true;
                 exclusion_idx += 1;
             } else {
-                sender.node.try_borrow_mut()?.info.excluded = false;
+                self.nodes[sender.vertex_id as usize]
+                    .try_borrow_mut()?
+                    .info
+                    .excluded = false;
             }
         }
         Ok(())

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,8 +1,9 @@
 use std::{cell::RefCell, cmp::Ordering, rc::Rc};
 
 use crate::{
+    errors::ASABRError,
     node_manager::NodeManager,
-    parsing::{Lexer, Parser, ParsingState},
+    parsing::{Lexer, Parser},
     types::{NodeID, NodeName, Token},
 };
 
@@ -103,34 +104,14 @@ impl Parser<NodeInfo> for NodeInfo {
     ///
     /// # Returns
     ///
-    /// * `ParsingState<NodeInfo>` - The parsing state, which can be either finished with the parsed node info,
+    /// * `Result<LexerOutput<NodeInfo>, ASABRError>` - The parsing state, which can be either finished with the parsed node info,
     ///   an error, or an EOF state.
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<NodeInfo> {
-        let id_state = NodeID::parse(lexer);
-        let id: NodeID = match id_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+    fn parse(lexer: &mut dyn Lexer) -> Result<NodeInfo, ASABRError> {
+        let id: NodeID = NodeID::parse(lexer)?;
 
-        let name_state = NodeName::parse(lexer);
-        let name: NodeName = match name_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+        let name: NodeName = NodeName::parse(lexer)?;
 
-        ParsingState::Finished(NodeInfo {
+        Ok(NodeInfo {
             id,
             name,
             excluded: false,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cell::RefCell, cmp::Ordering, rc::Rc};
 
 use crate::{
     node_manager::NodeManager,
@@ -32,6 +32,8 @@ pub struct Node<NM: NodeManager> {
     /// The manager responsible for handling the node's operations.
     pub manager: NM,
 }
+
+pub type SharedNode<NM> = Rc<RefCell<Node<NM>>>;
 
 impl<NM: NodeManager> Node<NM> {
     /// Tries to create a new instance of `Node`.

--- a/src/node_manager/none.rs
+++ b/src/node_manager/none.rs
@@ -1,4 +1,5 @@
-use crate::parsing::{DispatchParser, Lexer, Parser, ParsingState};
+use crate::errors::ASABRError;
+use crate::parsing::{DispatchParser, Lexer, Parser};
 
 #[cfg(any(feature = "node_proc", feature = "node_tx", feature = "node_rx"))]
 use crate::{bundle::Bundle, types::Date};
@@ -48,7 +49,7 @@ impl DispatchParser<NoManagement> for NoManagement {}
 
 /// The parser doesn't need to read tokens.
 impl Parser<NoManagement> for NoManagement {
-    fn parse(_lexer: &mut dyn Lexer) -> ParsingState<NoManagement> {
-        ParsingState::Finished(NoManagement {})
+    fn parse(_lexer: &mut dyn Lexer) -> Result<NoManagement, ASABRError> {
+        Ok(NoManagement {})
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,17 +1,17 @@
 use std::{collections::HashMap, str::FromStr};
 
-use crate::{contact_manager::ContactManager, node_manager::NodeManager};
+use crate::{contact_manager::ContactManager, errors::ASABRError, node_manager::NodeManager};
 
 pub type ContactMarkerMap<'a> = Dispatcher<'a, ContactDispatcher>;
 pub type NodeMarkerMap<'a> = Dispatcher<'a, NodeDispatcher>;
-pub type ContactDispatcher = fn(&mut dyn Lexer) -> ParsingState<Box<dyn ContactManager>>;
-pub type NodeDispatcher = fn(&mut dyn Lexer) -> ParsingState<Box<dyn NodeManager>>;
+pub type ContactDispatcher = fn(&mut dyn Lexer) -> Result<Box<dyn ContactManager>, ASABRError>;
+pub type NodeDispatcher = fn(&mut dyn Lexer) -> Result<Box<dyn NodeManager>, ASABRError>;
 
 pub type StaticMarkerMap<'a, M> = Dispatcher<'a, StaticDispatcher<M>>;
-pub type StaticDispatcher<M> = fn(&mut dyn Lexer) -> ParsingState<M>;
+pub type StaticDispatcher<M> = fn(&mut dyn Lexer) -> Result<M, ASABRError>;
 
 impl<T: FromStr> Parser<Vec<T>> for Vec<T> {
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<Vec<T>> {
+    fn parse(lexer: &mut dyn Lexer) -> Result<Vec<T>, ASABRError> {
         let mut items = Vec::new();
         let mut started = false;
 
@@ -29,19 +29,23 @@ impl<T: FromStr> Parser<Vec<T>> for Vec<T> {
         };
 
         loop {
-            let token = match lexer.consume_next_token() {
-                ParsingState::Finished(t) => t,
-                ParsingState::EOF => return ParsingState::EOF,
-                ParsingState::Error(e) => return ParsingState::Error(e),
+            let token = match lexer.consume_next_token()? {
+                LexerOutput::Finished(t) => t,
+                LexerOutput::EOF => {
+                    return Err(ASABRError::ParsingError(format!(
+                        "Parsing failed, expected ']' ({})",
+                        lexer.get_current_position()
+                    )));
+                }
             };
             let token = token.trim();
 
             if !started {
                 if !token.starts_with('[') {
-                    return ParsingState::Error(format!(
+                    return Err(ASABRError::ParsingError(format!(
                         "Parsing failed, expected '[' ({})",
                         lexer.get_current_position()
-                    ));
+                    )));
                 }
                 started = true;
             }
@@ -55,14 +59,14 @@ impl<T: FromStr> Parser<Vec<T>> for Vec<T> {
             };
 
             if !try_push(inner, &mut items) {
-                return ParsingState::Error(format!(
+                return Err(ASABRError::ParsingError(format!(
                     "Parsing failed ({})",
                     lexer.get_current_position()
-                ));
+                )));
             }
 
             if closes {
-                return ParsingState::Finished(items);
+                return Ok(items);
             }
         }
     }
@@ -116,12 +120,10 @@ impl<'a, T> Dispatcher<'a, T> {
     }
 }
 
-/// Represents the state of parsing for a generic type.
-pub enum ParsingState<T> {
+/// Represents the successful outcome of a parsing step.
+pub enum LexerOutput<T> {
     /// Indicates that the end of the file has been reached.
     EOF,
-    /// Contains an error message indicating what went wrong during parsing.
-    Error(String),
     /// Contains the successfully parsed value of type `T`.
     Finished(T),
 }
@@ -129,9 +131,9 @@ pub enum ParsingState<T> {
 /// Trait for a lexer that reads input and returns parsed tokens.
 pub trait Lexer {
     /// Looks up the next token in the input stream.
-    fn lookup(&mut self) -> ParsingState<String>;
+    fn lookup(&mut self) -> Result<LexerOutput<String>, ASABRError>;
     /// Consumes and returns the next token from the input stream.
-    fn consume_next_token(&mut self) -> ParsingState<String>;
+    fn consume_next_token(&mut self) -> Result<LexerOutput<String>, ASABRError>;
     /// Returns the current position in the input stream.
     fn get_current_position(&self) -> String;
 }
@@ -139,19 +141,14 @@ pub trait Lexer {
 /// Trait for parsing a generic type `T` from a lexer.
 pub trait Parser<T> {
     ///  Parses an instance of type `T` from the provided lexer.
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<T>;
+    fn parse(lexer: &mut dyn Lexer) -> Result<T, ASABRError>;
 }
 
 /// Delegate the parsing logic to the boxed Parser type.
 impl<T: Parser<T>> Parser<Box<T>> for Box<T> {
     ///  Parses an instance of type `T` an return a boxed type.
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<Box<T>> {
-        let ret = T::parse(lexer);
-        match ret {
-            ParsingState::EOF => ParsingState::EOF,
-            ParsingState::Error(msg) => ParsingState::Error(msg),
-            ParsingState::Finished(val) => ParsingState::Finished(Box::new(val)),
-        }
+    fn parse(lexer: &mut dyn Lexer) -> Result<Box<T>, ASABRError> {
+        Ok(Box::new(T::parse(lexer)?))
     }
 }
 
@@ -160,8 +157,10 @@ macro_rules! implement_parser {
     ($manager_type:ident) => {
         /// Dispatching is impossible for concrete Parser types.
         impl Parser<Box<dyn $manager_type>> for Box<dyn $manager_type> {
-            fn parse(_lexer: &mut dyn Lexer) -> ParsingState<Box<dyn $manager_type>> {
-                panic!("Unable to dispatch to the correct parser, the Dispatcher");
+            fn parse(_lexer: &mut dyn Lexer) -> Result<Box<dyn $manager_type>, ASABRError> {
+                Err(ASABRError::ParsingError(
+                    "Unable to dispatch to the correct parser, the Dispatcher".to_string(),
+                ))
             }
         }
     };
@@ -179,38 +178,15 @@ implement_parser!(ContactManager);
 ///
 /// # Returns
 ///
-/// * `ParsingState<(INFO, MANAGER)>` - The parsing state containing either the parsed components or an error.
+/// * `Result<LexerOutput<(INFO, MANAGER)>, ASABRError>` - The parsing state containing either the parsed components or an error.
 pub fn parse_components<INFO: Parser<INFO>, MANAGER: DispatchParser<MANAGER> + Parser<MANAGER>>(
     lexer: &mut dyn Lexer,
     dispatch_map: Option<&StaticMarkerMap<MANAGER>>,
-) -> ParsingState<(INFO, MANAGER)> {
-    let info: INFO;
-    let manager: MANAGER;
+) -> Result<(INFO, MANAGER), ASABRError> {
+    let info = INFO::parse(lexer)?;
 
-    let info_state = INFO::parse(lexer);
-    match info_state {
-        ParsingState::Finished(value) => info = value,
-        ParsingState::Error(msg) => return ParsingState::Error(msg),
-        ParsingState::EOF => {
-            return ParsingState::Error(format!(
-                "Parsing failed ({})",
-                lexer.get_current_position()
-            ));
-        }
-    }
-
-    let manager_state = MANAGER::parse_dispatch(lexer, dispatch_map);
-    match manager_state {
-        ParsingState::Finished(value) => manager = value,
-        ParsingState::Error(msg) => return ParsingState::Error(msg),
-        ParsingState::EOF => {
-            return ParsingState::Error(format!(
-                "Parsing failed ({})",
-                lexer.get_current_position()
-            ));
-        }
-    }
-    ParsingState::Finished((info, manager))
+    let manager = MANAGER::parse_dispatch(lexer, dispatch_map)?;
+    Ok((info, manager))
 }
 
 /// Trait for parsing a manager type `T` from a lexer.
@@ -226,19 +202,18 @@ pub trait DispatchParser<T: Parser<T>> {
     /// * `lexer` - A mutable reference to the lexer that is used to read the manager component.
     ///     - **Type**: `&mut dyn Lexer`
     /// * `marker_map` - An optional map of markers to functions that can parse specific types of managers.
-    ///     - **Type**: `Option<&Dispatcher<fn(&mut dyn Lexer) -> ParsingState<T>>>`
+    ///     - **Type**: `Option<&Dispatcher<fn(&mut dyn Lexer) -> Result<LexerOutput<T>, ASABRError>>>`
     ///     - This map allows dynamic dispatch of the parsing functions based on the markers found in the input.
     ///
     /// # Returns
     ///
-    /// * `ParsingState<T>` - The parsing state which can be:
-    ///     - `Finished(T)` - Indicates successful parsing with the parsed manager component.
-    ///     - `Error(String)` - Indicates an error encountered during parsing with an error message.
-    ///     - `EOF` - Indicates the end of the input stream, suggesting that parsing cannot continue.
+    /// * `Result<LexerOutput<T>, ASABRError>` - The parsing state which can be:
+    ///     - `Ok(T)` - Indicates successful parsing with the parsed manager component.
+    ///     - `Err(ASABRError::ParsingError(String))` - Indicates an error encountered during parsing with an error message.
     fn parse_dispatch(
         lexer: &mut dyn Lexer,
         _marker_map: Option<&StaticMarkerMap<T>>,
-    ) -> ParsingState<T> {
+    ) -> Result<T, ASABRError> {
         T::parse(lexer)
     }
 }
@@ -248,8 +223,8 @@ impl<T: DispatchParser<T> + Parser<T>> DispatchParser<Box<T>> for Box<T> {
     /// Delegates the parsing to the Parser trait.
     fn parse_dispatch(
         lexer: &mut dyn Lexer,
-        _: Option<&Dispatcher<fn(&mut dyn Lexer) -> ParsingState<Box<T>>>>,
-    ) -> ParsingState<Box<T>> {
+        _: Option<&Dispatcher<fn(&mut dyn Lexer) -> Result<Box<T>, ASABRError>>>,
+    ) -> Result<Box<T>, ASABRError> {
         <Box<T>>::parse(lexer)
     }
 }
@@ -263,18 +238,13 @@ impl<T: DispatchParser<T> + Parser<T>> DispatchParser<Box<T>> for Box<T> {
 macro_rules! implement_manager {
     ($manager_type:ident, $coerce_fn:ident) => {
         /// Forces parsing to a concrete type and returns the boxed value as a boxed dynamic type.
-        pub fn $coerce_fn<'a, M>(lexer: &mut dyn Lexer) -> ParsingState<Box<dyn $manager_type + 'a>>
+        pub fn $coerce_fn<'a, M>(
+            lexer: &mut dyn Lexer,
+        ) -> Result<Box<dyn $manager_type + 'a>, ASABRError>
         where
             M: $manager_type + Parser<M> + 'a,
         {
-            let ret = M::parse(lexer);
-            match ret {
-                ParsingState::EOF => ParsingState::EOF,
-                ParsingState::Error(msg) => ParsingState::Error(msg),
-                ParsingState::Finished(val) => {
-                    ParsingState::Finished(Box::new(val) as Box<dyn $manager_type + 'a>)
-                }
-            }
+            Ok(Box::new(M::parse(lexer)?) as Box<dyn $manager_type + 'a>)
         }
 
         /// Delegates the parsing to the correct Parser concrete implementation after dispatching.
@@ -283,31 +253,34 @@ macro_rules! implement_manager {
             fn parse_dispatch(
                 lexer: &mut dyn Lexer,
                 marker_map_opt: Option<
-                    &Dispatcher<fn(&mut dyn Lexer) -> ParsingState<Box<dyn $manager_type>>>,
+                    &Dispatcher<fn(&mut dyn Lexer) -> Result<Box<dyn $manager_type>, ASABRError>>,
                 >,
-            ) -> ParsingState<Box<dyn $manager_type>> {
-                let res = lexer.consume_next_token();
-                match res {
-                    ParsingState::EOF => ParsingState::EOF,
-                    ParsingState::Error(msg) => ParsingState::Error(msg),
-                    ParsingState::Finished(marker) => {
-                        let Some(marker_map) = marker_map_opt else {
-                            return ParsingState::Error(format!(
-                                "Dynamic parsing requires a map ({})",
-                                lexer.get_current_position()
-                            ));
-                        };
-
-                        let Some(parse_fn) = marker_map.get(marker.as_str()) else {
-                            return ParsingState::Error(format!(
-                                "Unrecognized marker ({})",
-                                lexer.get_current_position()
-                            ));
-                        };
-
-                        parse_fn(lexer)
+            ) -> Result<Box<dyn $manager_type>, ASABRError> {
+                let marker = match lexer.consume_next_token()? {
+                    LexerOutput::EOF => {
+                        return Err(ASABRError::ParsingError(format!(
+                            "Marker expected ({})",
+                            lexer.get_current_position()
+                        )));
                     }
-                }
+                    LexerOutput::Finished(marker) => marker,
+                };
+
+                let Some(marker_map) = marker_map_opt else {
+                    return Err(ASABRError::ParsingError(format!(
+                        "Dynamic parsing requires a map ({})",
+                        lexer.get_current_position()
+                    )));
+                };
+
+                let Some(parse_fn) = marker_map.get(marker.as_str()) else {
+                    return Err(ASABRError::ParsingError(format!(
+                        "Unrecognized marker ({})",
+                        lexer.get_current_position()
+                    )));
+                };
+
+                parse_fn(lexer)
             }
         }
     };

--- a/src/pathfinding/contact_parenting.rs
+++ b/src/pathfinding/contact_parenting.rs
@@ -150,9 +150,9 @@ macro_rules! define_contact_graph {
                         }
                     }
 
-                    let sender = &mut graph.senders[tx_node_id as usize];
+                    let sender = &graph.senders[tx_node_id as usize];
 
-                    for receiver in &mut sender.receivers {
+                    for receiver in &sender.receivers {
                         if $with_exclusions {
                             if receiver.is_excluded() {
                                 continue;
@@ -167,8 +167,7 @@ macro_rules! define_contact_graph {
                                 &from_route,
                                 &bundle,
                                 &receiver.contacts_to_receiver,
-                                &sender.node,
-                                &receiver.node,
+                                &graph.nodes,
                             ) {
                                 let mut push = false;
                                 if let Some(hop) = &route_proposition.via {

--- a/src/pathfinding/contact_parenting.rs
+++ b/src/pathfinding/contact_parenting.rs
@@ -154,7 +154,7 @@ macro_rules! define_contact_graph {
 
                     for receiver in &sender.receivers {
                         if $with_exclusions {
-                            if receiver.is_excluded() {
+                            if receiver.is_excluded(&graph.nodes) {
                                 continue;
                             }
                         }
@@ -187,7 +187,7 @@ macro_rules! define_contact_graph {
                                     }
                                 }
                                 if push {
-                                    let rx_node_id = receiver.node.borrow().info.id;
+                                    let rx_node_id = receiver.vertex_id;
 
                                     if let Some(hop) = &route_proposition.via {
                                         let route_proposition_ref = Rc::new(RefCell::new(

--- a/src/pathfinding/contact_parenting.rs
+++ b/src/pathfinding/contact_parenting.rs
@@ -166,6 +166,7 @@ macro_rules! define_contact_graph {
                                 first_contact_index,
                                 &from_route,
                                 &bundle,
+                                receiver.vertex_id,
                                 &receiver.contacts_to_receiver,
                                 &graph.real_nodes,
                             ) {

--- a/src/pathfinding/contact_parenting.rs
+++ b/src/pathfinding/contact_parenting.rs
@@ -60,7 +60,7 @@ macro_rules! define_contact_graph {
             fn new(multigraph: Rc<RefCell<Multigraph<NM, CM>>>) -> Self {
                 let mut node_count: usize = 0;
                 if $is_tree_output {
-                    node_count = multigraph.borrow().get_node_count();
+                    node_count = multigraph.borrow().get_vertex_count();
                 }
 
                 Self {
@@ -154,7 +154,7 @@ macro_rules! define_contact_graph {
 
                     for receiver in &sender.receivers {
                         if $with_exclusions {
-                            if receiver.is_excluded(&graph.nodes) {
+                            if receiver.is_excluded(&graph.real_nodes) {
                                 continue;
                             }
                         }
@@ -167,7 +167,7 @@ macro_rules! define_contact_graph {
                                 &from_route,
                                 &bundle,
                                 &receiver.contacts_to_receiver,
-                                &graph.nodes,
+                                &graph.real_nodes,
                             ) {
                                 let mut push = false;
                                 if let Some(hop) = &route_proposition.via {

--- a/src/pathfinding/hybrid_parenting.rs
+++ b/src/pathfinding/hybrid_parenting.rs
@@ -327,7 +327,7 @@ macro_rules! define_mpt {
 
                     for receiver in &sender.receivers {
                         if $with_exclusions {
-                            if receiver.is_excluded() {
+                            if receiver.is_excluded(&graph.nodes) {
                                 continue;
                             }
                         }

--- a/src/pathfinding/hybrid_parenting.rs
+++ b/src/pathfinding/hybrid_parenting.rs
@@ -302,7 +302,7 @@ macro_rules! define_mpt {
                     bundle,
                     source_route.clone(),
                     excluded_nodes_sorted,
-                    graph.get_node_count(),
+                    graph.get_vertex_count(),
                 );
                 let mut priority_queue: BinaryHeap<Reverse<DistanceWrapper<NM, CM, D>>> =
                     BinaryHeap::new();
@@ -327,7 +327,7 @@ macro_rules! define_mpt {
 
                     for receiver in &sender.receivers {
                         if $with_exclusions {
-                            if receiver.is_excluded(&graph.nodes) {
+                            if receiver.is_excluded(&graph.real_nodes) {
                                 continue;
                             }
                         }
@@ -339,7 +339,7 @@ macro_rules! define_mpt {
                                 &from_route,
                                 bundle,
                                 &receiver.contacts_to_receiver,
-                                &graph.nodes,
+                                &graph.real_nodes,
                             )
                             // This transforms a prop in the stack to a prop in the heap
                             && let Some(new_route) =

--- a/src/pathfinding/hybrid_parenting.rs
+++ b/src/pathfinding/hybrid_parenting.rs
@@ -323,9 +323,9 @@ macro_rules! define_mpt {
                         }
                     }
 
-                    let sender = &mut graph.senders[tx_node_id as usize];
+                    let sender = &graph.senders[tx_node_id as usize];
 
-                    for receiver in &mut sender.receivers {
+                    for receiver in &sender.receivers {
                         if $with_exclusions {
                             if receiver.is_excluded() {
                                 continue;
@@ -339,8 +339,7 @@ macro_rules! define_mpt {
                                 &from_route,
                                 bundle,
                                 &receiver.contacts_to_receiver,
-                                &sender.node,
-                                &receiver.node,
+                                &graph.nodes,
                             )
                             // This transforms a prop in the stack to a prop in the heap
                             && let Some(new_route) =

--- a/src/pathfinding/hybrid_parenting.rs
+++ b/src/pathfinding/hybrid_parenting.rs
@@ -338,6 +338,7 @@ macro_rules! define_mpt {
                                 first_contact_index,
                                 &from_route,
                                 bundle,
+                                receiver.vertex_id,
                                 &receiver.contacts_to_receiver,
                                 &graph.real_nodes,
                             )
@@ -550,6 +551,59 @@ mod tests {
             .expect("Routing Failed !");
 
         assert_time_hop(&res_sabr, 4, 50.0, 3, "SABR");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_vnode_anycast_tree() -> Result<(), ASABRError> {
+        let mg = vnode_anycast_graph()?;
+
+        let mut algo = HybridParentingTreeExcl::<NoManagement, EVLManager, SABR>::new(mg.clone());
+
+        let bundle = make_bundle(5, 1, 1.0, 2000.0);
+
+        let res = algo
+            .get_next(0.0, 0, &bundle, &[][..])
+            .expect("Routing to vnode failed!");
+
+        assert!(
+            res.by_destination[5].is_some(),
+            "VNode V(5) should be reachable"
+        );
+
+        let vnode_route = res.by_destination[5].as_ref().unwrap().borrow();
+        assert_eq!(
+            vnode_route.to_node, 5,
+            "Route to_node should be vnode vertex ID (5), got {}",
+            vnode_route.to_node
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_vnode_anycast_path() -> Result<(), ASABRError> {
+        let mg = vnode_anycast_graph()?;
+
+        let mut algo = HybridParentingPathExcl::<NoManagement, EVLManager, SABR>::new(mg.clone());
+
+        let bundle = make_bundle(5, 1, 1.0, 2000.0);
+
+        let res = algo
+            .get_next(0.0, 0, &bundle, &[][..])
+            .expect("Routing to vnode failed!");
+
+        assert!(
+            res.by_destination[5].is_some(),
+            "VNode V(5) should be reachable via path search"
+        );
+
+        let vnode_route = res.by_destination[5].as_ref().unwrap().borrow();
+        assert_eq!(
+            vnode_route.to_node, 5,
+            "Route to_node should be vnode ID (5)"
+        );
 
         Ok(())
     }

--- a/src/pathfinding/limiting_contact/mod.rs
+++ b/src/pathfinding/limiting_contact/mod.rs
@@ -130,7 +130,7 @@ macro_rules! create_new_alternative_path_variant {
             fn new(
                 multigraph: std::rc::Rc<std::cell::RefCell<$crate::multigraph::Multigraph<NM, CM>>>
             ) -> Self {
-                let node_count = multigraph.borrow().get_node_count();
+                let node_count = multigraph.borrow().get_vertex_count();
                 Self {
 
                     pathfinding: P::new(multigraph),

--- a/src/pathfinding/mod.rs
+++ b/src/pathfinding/mod.rs
@@ -178,7 +178,7 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
     for (idx, contact) in contacts.iter().enumerate().skip(first_contact_index) {
         let contact_borrowed = contact.borrow();
         #[cfg(feature = "node_proc")]
-        let tx_node = &nodes[contact_borrowed.info.tx_node as usize];
+        let tx_node = &nodes[contact_borrowed.info.tx_node_id as usize];
 
         #[cfg(feature = "contact_suppression")]
         if contact_borrowed.suppressed {
@@ -204,8 +204,8 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
             sending_time,
             &bundle_to_consider,
         ) {
-            let tx_node = &nodes[contact_borrowed.info.tx_node as usize];
-            let rx_node = &nodes[contact_borrowed.info.rx_node as usize];
+            let tx_node = &nodes[contact_borrowed.info.tx_node_id as usize];
+            let rx_node = &nodes[contact_borrowed.info.rx_node_id as usize];
 
             #[cfg(feature = "node_tx")]
             if !tx_node.borrow().manager.dry_run_tx(
@@ -241,7 +241,7 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
         let selected_contact = &contacts[index];
         let mut route_proposition: RouteStage<NM, CM> = RouteStage::new(
             final_data.rx_end,
-            selected_contact.borrow().get_rx_node(),
+            selected_contact.borrow().get_rx_node_id(),
             Some(ViaHop {
                 contact: selected_contact.clone(),
                 parent_route: sndr_route.clone(),

--- a/src/pathfinding/mod.rs
+++ b/src/pathfinding/mod.rs
@@ -3,7 +3,7 @@ use crate::contact::Contact;
 use crate::contact_manager::{ContactManager, ContactManagerTxData};
 use crate::errors::ASABRError;
 use crate::multigraph::Multigraph;
-use crate::node::Node;
+use crate::node::{Node, SharedNode};
 use crate::node_manager::NodeManager;
 use crate::route_stage::ViaHop;
 use crate::route_stage::{RouteStage, SharedRouteStage};
@@ -148,8 +148,7 @@ pub trait Pathfinding<NM: NodeManager, CM: ContactManager> {
 /// * `sndr_route` - A reference-counted, mutable `RouteStage` that represents the sender's current route.
 /// * `bundle` - A reference to the `Bundle` that is being routed.
 /// * `contacts` - A vector of reference-counted, mutable `Contact`s representing available transmission opportunities.
-/// * `tx_node` - A reference-counted, mutable `Node` representing the transmitting node.
-/// * `rx_node` - A reference-counted, mutable `Node` representing the receiving node.
+/// * `nodes` - A reference to the vector of reference-counted, mutable `Node`s of the Multigraph.
 ///
 /// # Returns
 ///
@@ -159,17 +158,14 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
     sndr_route: &SharedRouteStage<NM, CM>,
     _bundle: &Bundle,
     contacts: &[Rc<RefCell<Contact<NM, CM>>>],
-    tx_node: &Rc<RefCell<Node<NM>>>,
-    rx_node: &Rc<RefCell<Node<NM>>>,
+    nodes: &[Rc<RefCell<Node<NM>>>],
 ) -> Option<RouteStage<NM, CM>> {
-    let mut index = 0;
-    let mut final_data = ContactManagerTxData {
-        tx_start: 0.0,
-        tx_end: 0.0,
-        expiration: 0.0,
-        rx_start: Date::MAX,
-        rx_end: Date::MAX,
-    };
+    let mut final_data_opt: Option<(
+        ContactManagerTxData,
+        &SharedNode<NM>,
+        &SharedNode<NM>,
+        usize,
+    )> = None;
 
     // If bundle processing is enabled, a mutable bundle copy is required to be attached to the RouteStage.
     #[cfg(feature = "node_proc")]
@@ -181,15 +177,19 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
 
     for (idx, contact) in contacts.iter().enumerate().skip(first_contact_index) {
         let contact_borrowed = contact.borrow();
+        #[cfg(feature = "node_proc")]
+        let tx_node = &nodes[contact_borrowed.info.tx_node as usize];
 
         #[cfg(feature = "contact_suppression")]
         if contact_borrowed.suppressed {
             continue;
         }
 
-        if contact_borrowed.info.start > final_data.rx_end {
+        if let Some((final_data, _, _, _)) = final_data_opt
+            && contact_borrowed.info.start > final_data.rx_end
+        {
             break;
-        }
+        };
 
         #[cfg(feature = "node_proc")]
         let sending_time = tx_node
@@ -204,6 +204,9 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
             sending_time,
             &bundle_to_consider,
         ) {
+            let tx_node = &nodes[contact_borrowed.info.tx_node as usize];
+            let rx_node = &nodes[contact_borrowed.info.rx_node as usize];
+
             #[cfg(feature = "node_tx")]
             if !tx_node.borrow().manager.dry_run_tx(
                 sending_time,
@@ -214,7 +217,12 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
                 continue;
             }
 
-            if hop.rx_end < final_data.rx_end {
+            let is_better = match &final_data_opt {
+                None => true,
+                Some((current, _, _, _)) => hop.rx_end < current.rx_end,
+            };
+
+            if is_better {
                 #[cfg(feature = "node_rx")]
                 if !rx_node
                     .borrow()
@@ -224,19 +232,18 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
                     continue;
                 }
 
-                final_data = hop;
-                index = idx;
+                final_data_opt = Some((hop, tx_node, rx_node, idx));
             }
         }
     }
 
-    if final_data.rx_end < Date::MAX {
-        let seleted_contact = &contacts[index];
+    if let Some((final_data, tx_node, rx_node, index)) = final_data_opt {
+        let selected_contact = &contacts[index];
         let mut route_proposition: RouteStage<NM, CM> = RouteStage::new(
             final_data.rx_end,
-            seleted_contact.borrow().get_rx_node(),
+            selected_contact.borrow().get_rx_node(),
             Some(ViaHop {
-                contact: seleted_contact.clone(),
+                contact: selected_contact.clone(),
                 parent_route: sndr_route.clone(),
                 tx_node: tx_node.clone(),
                 rx_node: rx_node.clone(),
@@ -278,10 +285,9 @@ mod tests {
         source: &SharedRouteStage<NM, EVLManager>,
         bundle: &Bundle,
         contacts: &[Rc<RefCell<Contact<NM, EVLManager>>>],
-        tx: &Rc<RefCell<Node<NM>>>,
-        rx: &Rc<RefCell<Node<NM>>>,
+        nodes: &[Rc<RefCell<Node<NM>>>],
     ) -> Option<RouteStage<NM, EVLManager>> {
-        try_make_hop(first_contact_index, source, bundle, contacts, tx, rx)
+        try_make_hop(first_contact_index, source, bundle, contacts, nodes)
     }
 
     #[test]
@@ -295,7 +301,7 @@ mod tests {
         let ctx = make_hop_context(50.0);
 
         let result: Option<RouteStage<NoManagement, EVLManager>> =
-            run_hop(0, &ctx.source, &ctx.bundle, &[], &ctx.tx, &ctx.rx);
+            run_hop(0, &ctx.source, &ctx.bundle, &[], &ctx.nodes);
 
         assert!(
             result.is_none(),
@@ -311,7 +317,7 @@ mod tests {
         )];
 
         let result: Option<RouteStage<NoManagement, EVLManager>> =
-            run_hop(1, &ctx.source, &ctx.bundle, &contacts, &ctx.tx, &ctx.rx);
+            run_hop(1, &ctx.source, &ctx.bundle, &contacts, &ctx.nodes);
 
         assert!(
             result.is_none(),
@@ -326,7 +332,7 @@ mod tests {
             0, 1, 0.0, 200.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &ctx.source, &ctx.bundle, &contacts, &ctx.tx, &ctx.rx);
+        let result = run_hop(0, &ctx.source, &ctx.bundle, &contacts, &ctx.nodes);
 
         assert!(
             result.is_none(),
@@ -341,7 +347,7 @@ mod tests {
             0, 1, 0.0, 200.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &ctx.source, &ctx.bundle, &contacts, &ctx.tx, &ctx.rx);
+        let result = run_hop(0, &ctx.source, &ctx.bundle, &contacts, &ctx.nodes);
 
         assert!(
             result.is_some(),
@@ -360,8 +366,7 @@ mod tests {
             &ctx.source,
             &ctx.bundle,
             &[contact_skipped, contact_used],
-            &ctx.tx,
-            &ctx.rx,
+            &ctx.nodes,
         );
 
         assert!(
@@ -392,8 +397,7 @@ mod tests {
             &ctx.source,
             &ctx.bundle,
             &[contact1, contact2, contact3],
-            &ctx.tx,
-            &ctx.rx,
+            &ctx.nodes,
         );
 
         assert!(
@@ -415,8 +419,7 @@ mod tests {
             &ctx.source,
             &ctx.bundle,
             &[contact_suppressed, contact_valid],
-            &ctx.tx,
-            &ctx.rx,
+            &ctx.nodes,
         );
 
         assert!(
@@ -438,11 +441,12 @@ mod tests {
         let source = make_source::<MockNodeManager>(0.0, 0, &bundle);
         let tx = make_node_rc(0, "A", MockNodeManager::refusing_tx());
         let rx = make_node_rc(1, "B", MockNodeManager::accepting());
+        let nodes = vec![tx, rx];
         let contacts = vec![make_contact_rc::<MockNodeManager>(
             0, 1, 0.0, 2000.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &source, &bundle, &contacts, &tx, &rx);
+        let result = run_hop(0, &source, &bundle, &contacts, &nodes);
 
         assert!(
             result.is_none(),
@@ -457,11 +461,12 @@ mod tests {
         let source = make_source::<MockNodeManager>(0.0, 0, &bundle);
         let tx = make_node_rc(0, "A", MockNodeManager::accepting());
         let rx = make_node_rc(1, "B", MockNodeManager::refusing_rx());
+        let nodes = vec![tx, rx];
         let contacts = vec![make_contact_rc::<MockNodeManager>(
             0, 1, 0.0, 2000.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &source, &bundle, &contacts, &tx, &rx);
+        let result = run_hop(0, &source, &bundle, &contacts, &nodes);
 
         assert!(
             result.is_none(),
@@ -476,11 +481,12 @@ mod tests {
         let source = make_source::<MockNodeManager>(0.0, 0, &bundle);
         let tx = make_node_rc(0, "A", MockNodeManager::processing(2.0));
         let rx = make_node_rc(1, "B", MockNodeManager::accepting());
+        let nodes = vec![tx, rx];
         let contacts = vec![make_contact_rc::<MockNodeManager>(
             0, 1, 0.0, 2000.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &source, &bundle, &contacts, &tx, &rx);
+        let result = run_hop(0, &source, &bundle, &contacts, &nodes);
 
         assert!(
             result.is_some(),
@@ -502,6 +508,7 @@ mod tests {
         let source = make_source::<NoManagement>(5.0, 0, &bundle);
         let tx = make_node_rc(0, "A", NoManagement {});
         let rx = make_node_rc(1, "B", NoManagement {});
+        let nodes = vec![tx, rx];
         // Contact A : arrival = 11.0
         let contact_a = make_contact_rc::<NoManagement>(0, 1, 0.0, 50.0, 100.0, 5.0);
         // Contact B : arrival = 8.0 -> should be the one returned
@@ -516,8 +523,7 @@ mod tests {
             &source,
             &bundle,
             &[contact_a, contact_b, contact_c, contact_d],
-            &tx,
-            &rx,
+            &nodes,
         );
 
         assert!(
@@ -569,8 +575,7 @@ mod tests {
             &ctx.source,
             &ctx.bundle,
             &[contact_a, contact_b],
-            &ctx.tx,
-            &ctx.rx,
+            &ctx.nodes,
         )
         .expect("TEST FAILED: Hop 1 should succeed.");
 
@@ -600,6 +605,9 @@ mod tests {
         let source2: SharedRouteStage<NoManagement, EVLManager> = Rc::new(RefCell::new(hop1));
         let tx1 = make_node_rc(1, "B", NoManagement {});
         let rx2 = make_node_rc(2, "C", NoManagement {});
+        let node0 = &ctx.nodes[0]; // Copy the first node previously built, so we have the complete
+        // 3-node graph.
+        let nodes = vec![node0.clone(), tx1, rx2];
 
         // Contacts with end = 1000.0 so that source2.expiration is the limiting factor
         // Contact C : arrival = 3.5 -> the best one
@@ -607,15 +615,8 @@ mod tests {
         // Contact D : arrival = 5.0
         let contact_d = make_contact_rc::<NoManagement>(1, 2, 0.0, 1000.0, 100.0, 2.0);
 
-        let hop2 = run_hop(
-            0,
-            &source2,
-            &ctx.bundle,
-            &[contact_c, contact_d],
-            &tx1,
-            &rx2,
-        )
-        .expect("TEST FAILED: Hop 2 should succeed.");
+        let hop2 = run_hop(0, &source2, &ctx.bundle, &[contact_c, contact_d], &nodes)
+            .expect("TEST FAILED: Hop 2 should succeed.");
 
         assert_eq!(
             hop2.at_time, 3.5,

--- a/src/pathfinding/mod.rs
+++ b/src/pathfinding/mod.rs
@@ -8,6 +8,7 @@ use crate::node_manager::NodeManager;
 use crate::route_stage::ViaHop;
 use crate::route_stage::{RouteStage, SharedRouteStage};
 use crate::types::{Date, NodeID};
+use crate::vertex::VertexID;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -157,6 +158,7 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
     first_contact_index: usize,
     sndr_route: &SharedRouteStage<NM, CM>,
     _bundle: &Bundle,
+    receiver_id: VertexID,
     contacts: &[Rc<RefCell<Contact<NM, CM>>>],
     nodes: &[Rc<RefCell<Node<NM>>>],
 ) -> Option<RouteStage<NM, CM>> {
@@ -241,7 +243,7 @@ fn try_make_hop<NM: NodeManager, CM: ContactManager>(
         let selected_contact = &contacts[index];
         let mut route_proposition: RouteStage<NM, CM> = RouteStage::new(
             final_data.rx_end,
-            selected_contact.borrow().get_rx_node_id(),
+            receiver_id,
             Some(ViaHop {
                 contact: selected_contact.clone(),
                 parent_route: sndr_route.clone(),
@@ -276,6 +278,7 @@ mod tests {
     use crate::node_manager::none::NoManagement;
     use crate::pathfinding::test_helpers::*;
     use crate::route_stage::RouteStage;
+    use crate::vertex::VertexID;
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -284,10 +287,18 @@ mod tests {
         first_contact_index: usize,
         source: &SharedRouteStage<NM, EVLManager>,
         bundle: &Bundle,
+        receiver_id: VertexID,
         contacts: &[Rc<RefCell<Contact<NM, EVLManager>>>],
         nodes: &[Rc<RefCell<Node<NM>>>],
     ) -> Option<RouteStage<NM, EVLManager>> {
-        try_make_hop(first_contact_index, source, bundle, contacts, nodes)
+        try_make_hop(
+            first_contact_index,
+            source,
+            bundle,
+            receiver_id,
+            contacts,
+            nodes,
+        )
     }
 
     #[test]
@@ -301,7 +312,7 @@ mod tests {
         let ctx = make_hop_context(50.0);
 
         let result: Option<RouteStage<NoManagement, EVLManager>> =
-            run_hop(0, &ctx.source, &ctx.bundle, &[], &ctx.nodes);
+            run_hop(0, &ctx.source, &ctx.bundle, 1, &[], &ctx.nodes);
 
         assert!(
             result.is_none(),
@@ -317,7 +328,7 @@ mod tests {
         )];
 
         let result: Option<RouteStage<NoManagement, EVLManager>> =
-            run_hop(1, &ctx.source, &ctx.bundle, &contacts, &ctx.nodes);
+            run_hop(1, &ctx.source, &ctx.bundle, 1, &contacts, &ctx.nodes);
 
         assert!(
             result.is_none(),
@@ -332,7 +343,7 @@ mod tests {
             0, 1, 0.0, 200.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &ctx.source, &ctx.bundle, &contacts, &ctx.nodes);
+        let result = run_hop(0, &ctx.source, &ctx.bundle, 1, &contacts, &ctx.nodes);
 
         assert!(
             result.is_none(),
@@ -347,7 +358,7 @@ mod tests {
             0, 1, 0.0, 200.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &ctx.source, &ctx.bundle, &contacts, &ctx.nodes);
+        let result = run_hop(0, &ctx.source, &ctx.bundle, 1, &contacts, &ctx.nodes);
 
         assert!(
             result.is_some(),
@@ -365,6 +376,7 @@ mod tests {
             1,
             &ctx.source,
             &ctx.bundle,
+            1,
             &[contact_skipped, contact_used],
             &ctx.nodes,
         );
@@ -396,6 +408,7 @@ mod tests {
             0,
             &ctx.source,
             &ctx.bundle,
+            1,
             &[contact1, contact2, contact3],
             &ctx.nodes,
         );
@@ -418,6 +431,7 @@ mod tests {
             0,
             &ctx.source,
             &ctx.bundle,
+            1,
             &[contact_suppressed, contact_valid],
             &ctx.nodes,
         );
@@ -446,7 +460,7 @@ mod tests {
             0, 1, 0.0, 2000.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &source, &bundle, &contacts, &nodes);
+        let result = run_hop(0, &source, &bundle, 1, &contacts, &nodes);
 
         assert!(
             result.is_none(),
@@ -466,7 +480,7 @@ mod tests {
             0, 1, 0.0, 2000.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &source, &bundle, &contacts, &nodes);
+        let result = run_hop(0, &source, &bundle, 1, &contacts, &nodes);
 
         assert!(
             result.is_none(),
@@ -486,7 +500,7 @@ mod tests {
             0, 1, 0.0, 2000.0, 100.0, 1.0,
         )];
 
-        let result = run_hop(0, &source, &bundle, &contacts, &nodes);
+        let result = run_hop(0, &source, &bundle, 1, &contacts, &nodes);
 
         assert!(
             result.is_some(),
@@ -522,6 +536,7 @@ mod tests {
             0,
             &source,
             &bundle,
+            1,
             &[contact_a, contact_b, contact_c, contact_d],
             &nodes,
         );
@@ -574,6 +589,7 @@ mod tests {
             0,
             &ctx.source,
             &ctx.bundle,
+            1,
             &[contact_a, contact_b],
             &ctx.nodes,
         )
@@ -615,7 +631,7 @@ mod tests {
         // Contact D : arrival = 5.0
         let contact_d = make_contact_rc::<NoManagement>(1, 2, 0.0, 1000.0, 100.0, 2.0);
 
-        let hop2 = run_hop(0, &source2, &ctx.bundle, &[contact_c, contact_d], &nodes)
+        let hop2 = run_hop(0, &source2, &ctx.bundle, 2, &[contact_c, contact_d], &nodes)
             .expect("TEST FAILED: Hop 2 should succeed.");
 
         assert_eq!(
@@ -642,6 +658,55 @@ mod tests {
         assert!(
             hop2.via.is_some(),
             "Hop 2 FAILED: Expected a ViaHop to be set."
+        );
+    }
+
+    #[test]
+    fn test_to_node_equals_receiver_vertex_id() {
+        let ctx = make_hop_context(50.0);
+        let contacts = vec![make_contact_rc::<NoManagement>(
+            0, 1, 0.0, 200.0, 100.0, 1.0,
+        )];
+
+        // Pass receiver_id = 1 (same as contact's rx_node_id): to_node should be 1
+        let result = run_hop(0, &ctx.source, &ctx.bundle, 1, &contacts, &ctx.nodes);
+        let route = result.expect("Expected a valid hop");
+        assert_eq!(
+            route.to_node, 1,
+            "to_node should equal the receiver_vertex_id (1), got {}",
+            route.to_node
+        );
+    }
+
+    #[test]
+    fn test_vnode_receiver_sets_to_node() {
+        let ctx = make_hop_context(50.0);
+        // Contact goes from real node 0 to real node 1
+        let contacts = vec![make_contact_rc::<NoManagement>(
+            0, 1, 0.0, 200.0, 100.0, 1.0,
+        )];
+
+        // Pass receiver_id = 42 (a vnode vertex ID, distinct from contact's rx_node_id = 1).
+        // to_node must be set to the receiver vertex ID, not the contact's rx_node_id.
+        let result = run_hop(0, &ctx.source, &ctx.bundle, 42, &contacts, &ctx.nodes);
+        let route = result.expect("Expected a valid hop even with a vnode receiver");
+        assert_eq!(
+            route.to_node, 42,
+            "to_node should equal the vnode receiver_vertex_id (42), got {}",
+            route.to_node
+        );
+
+        // The ViaHop should still reference the real nodes from the contact
+        let via = route.via.as_ref().expect("Expected a ViaHop");
+        assert_eq!(
+            via.tx_node.borrow().info.id,
+            0,
+            "ViaHop tx_node should be the real tx node (0)"
+        );
+        assert_eq!(
+            via.rx_node.borrow().info.id,
+            1,
+            "ViaHop rx_node should be the real rx node (1), not the vnode"
         );
     }
 }

--- a/src/pathfinding/node_parenting.rs
+++ b/src/pathfinding/node_parenting.rs
@@ -124,7 +124,7 @@ macro_rules! define_node_graph {
 
                     for receiver in &sender.receivers {
                         if $with_exclusions {
-                            if receiver.is_excluded() {
+                            if receiver.is_excluded(&graph.nodes) {
                                 continue;
                             }
                         }
@@ -139,7 +139,7 @@ macro_rules! define_node_graph {
                                 &graph.nodes,
                             )
                         {
-                            let idx = receiver.node.borrow().info.id as usize;
+                            let idx = receiver.vertex_id as usize;
                             let push = match tree.by_destination[idx].as_ref() {
                                 Some(known_route_ref) => {
                                     let mut known_route = known_route_ref.try_borrow_mut()?;

--- a/src/pathfinding/node_parenting.rs
+++ b/src/pathfinding/node_parenting.rs
@@ -135,6 +135,7 @@ macro_rules! define_node_graph {
                                 first_contact_index,
                                 &from_route,
                                 bundle,
+                                receiver.vertex_id,
                                 &receiver.contacts_to_receiver,
                                 &graph.real_nodes,
                             )
@@ -353,6 +354,97 @@ mod tests {
             .expect("Routing Failed !");
 
         assert_time_hop(&res_sabr, 4, 50.0, 4, "SABR");
+
+        Ok(())
+    }
+
+    /// Tests anycast routing via a vnode.
+    ///
+    /// VNode V(5) labels real nodes C(2) and E(4).
+    /// Path to C: A->B->C (arrival = 2.02, 2 hops)
+    /// Path to E: A->D->E (arrival = 1.01, 2 hops)
+    ///
+    /// Routing to vnode V(5) should find the faster path through E.
+    #[test]
+    fn test_vnode_anycast_tree() -> Result<(), ASABRError> {
+        let mg = vnode_anycast_graph()?;
+
+        let mut algo = NodeParentingTreeExcl::<NoManagement, EVLManager, SABR>::new(mg.clone());
+
+        // Destination is the vnode V(5)
+        let bundle = make_bundle(5, 1, 1.0, 2000.0);
+
+        let res = algo
+            .get_next(0.0, 0, &bundle, &[][..])
+            .expect("Routing to vnode failed!");
+
+        // The vnode vertex (index 5) should have a route
+        assert!(
+            res.by_destination[5].is_some(),
+            "VNode V(5) should be reachable"
+        );
+
+        let vnode_route = res.by_destination[5].as_ref().unwrap().borrow();
+        // to_node should be the vnode vertex ID (5), not a real node ID
+        assert_eq!(
+            vnode_route.to_node, 5,
+            "Route to vnode should have to_node = vnode vertex ID (5), got {}",
+            vnode_route.to_node
+        );
+
+        // The real nodes C(2) and E(4) should also be reachable
+        assert!(
+            res.by_destination[2].is_some(),
+            "Real node C(2) should be reachable"
+        );
+        assert!(
+            res.by_destination[4].is_some(),
+            "Real node E(4) should be reachable"
+        );
+
+        // The vnode route's ViaHop should reference real nodes (not the vnode)
+        let via = vnode_route
+            .via
+            .as_ref()
+            .expect("VNode route should have a ViaHop");
+        let real_rx_id = via.rx_node.borrow().info.id;
+        assert!(
+            real_rx_id == 2 || real_rx_id == 4,
+            "ViaHop rx_node should be a real node in the vnode group (2 or 4), got {real_rx_id}",
+        );
+
+        Ok(())
+    }
+
+    /// Tests that routing to a vnode correctly picks the faster path.
+    ///
+    /// VNode V(5) labels real nodes C(2) and E(4).
+    /// The unicast pathfinder should stop at V(5) once it is popped from
+    /// the priority queue, having found the best route (through E, faster).
+    #[test]
+    fn test_vnode_anycast_path() -> Result<(), ASABRError> {
+        let mg = vnode_anycast_graph()?;
+
+        let mut algo = NodeParentingPathExcl::<NoManagement, EVLManager, SABR>::new(mg.clone());
+
+        // Destination is the vnode V(5)
+        let bundle = make_bundle(5, 1, 1.0, 2000.0);
+
+        let res = algo
+            .get_next(0.0, 0, &bundle, &[][..])
+            .expect("Routing to vnode failed!");
+
+        // V(5) should be reachable
+        assert!(
+            res.by_destination[5].is_some(),
+            "VNode V(5) should be reachable via path search"
+        );
+
+        let vnode_route = res.by_destination[5].as_ref().unwrap().borrow();
+        assert_eq!(
+            vnode_route.to_node, 5,
+            "Route to_node should be vnode ID (5)"
+        );
 
         Ok(())
     }

--- a/src/pathfinding/node_parenting.rs
+++ b/src/pathfinding/node_parenting.rs
@@ -119,9 +119,10 @@ macro_rules! define_node_graph {
                             break;
                         }
                     }
-                    let sender = &mut graph.senders[tx_node_id as usize];
 
-                    for receiver in &mut sender.receivers {
+                    let sender = &graph.senders[tx_node_id as usize];
+
+                    for receiver in &sender.receivers {
                         if $with_exclusions {
                             if receiver.is_excluded() {
                                 continue;
@@ -135,8 +136,7 @@ macro_rules! define_node_graph {
                                 &from_route,
                                 bundle,
                                 &receiver.contacts_to_receiver,
-                                &sender.node,
-                                &receiver.node,
+                                &graph.nodes,
                             )
                         {
                             let idx = receiver.node.borrow().info.id as usize;

--- a/src/pathfinding/node_parenting.rs
+++ b/src/pathfinding/node_parenting.rs
@@ -99,7 +99,7 @@ macro_rules! define_node_graph {
                 let mut priority_queue: BinaryHeap<Reverse<DistanceWrapper<NM, CM, D>>> =
                     BinaryHeap::new();
 
-                for node_id in 0..graph.get_node_count() {
+                for node_id in 0..graph.get_vertex_count() {
                     if node_id == source as usize {
                         tree.by_destination[node_id as usize] = Some(source_route.clone());
                     } else {
@@ -124,7 +124,7 @@ macro_rules! define_node_graph {
 
                     for receiver in &sender.receivers {
                         if $with_exclusions {
-                            if receiver.is_excluded(&graph.nodes) {
+                            if receiver.is_excluded(&graph.real_nodes) {
                                 continue;
                             }
                         }
@@ -136,7 +136,7 @@ macro_rules! define_node_graph {
                                 &from_route,
                                 bundle,
                                 &receiver.contacts_to_receiver,
-                                &graph.nodes,
+                                &graph.real_nodes,
                             )
                         {
                             let idx = receiver.vertex_id as usize;

--- a/src/pathfinding/test_helpers.rs
+++ b/src/pathfinding/test_helpers.rs
@@ -250,8 +250,7 @@ pub(crate) fn exemple_2_graph()
 pub(crate) struct HopContext<NM: NodeManager> {
     pub bundle: Bundle,
     pub source: SharedRouteStage<NM, EVLManager>,
-    pub tx: Rc<RefCell<Node<NM>>>,
-    pub rx: Rc<RefCell<Node<NM>>>,
+    pub nodes: Vec<Rc<RefCell<Node<NM>>>>,
 }
 
 pub(crate) fn make_hop_context(size: f64) -> HopContext<NoManagement> {
@@ -259,10 +258,10 @@ pub(crate) fn make_hop_context(size: f64) -> HopContext<NoManagement> {
     let source = make_source::<NoManagement>(0.0, 0, &bundle);
     let tx = make_node_rc(0, "A", NoManagement {});
     let rx = make_node_rc(1, "B", NoManagement {});
+    let nodes = vec![tx, rx];
     HopContext {
         bundle,
         source,
-        tx,
-        rx,
+        nodes,
     }
 }

--- a/src/pathfinding/test_helpers.rs
+++ b/src/pathfinding/test_helpers.rs
@@ -13,6 +13,7 @@ use crate::pathfinding::NodeID;
 use crate::pathfinding::PathFindingOutput;
 use crate::route_stage::{RouteStage, SharedRouteStage};
 use crate::types::Date;
+use crate::vertex::Vertex;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -84,20 +85,26 @@ impl NodeManager for MockNodeManager {
     }
 }
 
-pub(crate) fn make_node<NM: NodeManager>(id: u16, name: &str, nm: NM) -> Node<NM> {
-    Node::try_new(
-        NodeInfo {
-            id,
-            name: name.into(),
-            excluded: false,
-        },
-        nm,
+pub(crate) fn make_vertex<NM: NodeManager>(id: u16, name: &str, nm: NM) -> Vertex<NM> {
+    Vertex::INode(
+        Node::try_new(
+            NodeInfo {
+                id,
+                name: name.into(),
+                excluded: false,
+            },
+            nm,
+        )
+        .unwrap(),
     )
-    .unwrap()
 }
 
 pub(crate) fn make_node_rc<NM: NodeManager>(id: u16, name: &str, nm: NM) -> Rc<RefCell<Node<NM>>> {
-    Rc::new(RefCell::new(make_node(id, name, nm)))
+    let vertex = make_vertex(id, name, nm);
+    match vertex {
+        Vertex::INode(node) => Rc::new(RefCell::new(node)),
+        _ => unreachable!(),
+    }
 }
 
 pub(crate) fn make_contact<NM: NodeManager>(
@@ -175,9 +182,9 @@ pub(crate) fn unit_graph_test()
 -> Result<Rc<RefCell<Multigraph<NoManagement, EVLManager>>>, ASABRError> {
     Ok(Rc::new(RefCell::new(Multigraph::new(ContactPlan::new(
         vec![
-            make_node(0, "A", NoManagement {}),
-            make_node(1, "B", NoManagement {}),
-            make_node(2, "C", NoManagement {}),
+            make_vertex(0, "A", NoManagement {}),
+            make_vertex(1, "B", NoManagement {}),
+            make_vertex(2, "C", NoManagement {}),
         ],
         vec![
             make_contact::<NoManagement>(0, 1, 0.0, 2000.0, 100.0, 1.0),
@@ -191,10 +198,10 @@ pub(crate) fn five_contact_graph_test()
 -> Result<Rc<RefCell<Multigraph<NoManagement, EVLManager>>>, ASABRError> {
     Ok(Rc::new(RefCell::new(Multigraph::new(ContactPlan::new(
         vec![
-            make_node(0, "A", NoManagement {}),
-            make_node(1, "B", NoManagement {}),
-            make_node(2, "C", NoManagement {}),
-            make_node(3, "D", NoManagement {}),
+            make_vertex(0, "A", NoManagement {}),
+            make_vertex(1, "B", NoManagement {}),
+            make_vertex(2, "C", NoManagement {}),
+            make_vertex(3, "D", NoManagement {}),
         ],
         vec![
             make_contact::<NoManagement>(0, 1, 0.0, 2000.0, 100.0, 0.01),
@@ -211,10 +218,10 @@ pub(crate) fn exemple_1_graph()
 -> Result<Rc<RefCell<Multigraph<NoManagement, EVLManager>>>, ASABRError> {
     Ok(Rc::new(RefCell::new(Multigraph::new(ContactPlan::new(
         vec![
-            make_node(0, "source", NoManagement {}),
-            make_node(1, "from_C0", NoManagement {}),
-            make_node(2, "from_C2_C1", NoManagement {}),
-            make_node(3, "from_C3", NoManagement {}),
+            make_vertex(0, "source", NoManagement {}),
+            make_vertex(1, "from_C0", NoManagement {}),
+            make_vertex(2, "from_C2_C1", NoManagement {}),
+            make_vertex(3, "from_C3", NoManagement {}),
         ],
         vec![
             make_contact::<NoManagement>(0, 1, 0.0, 10.0, 1.0, 0.0),
@@ -230,11 +237,11 @@ pub(crate) fn exemple_2_graph()
 -> Result<Rc<RefCell<Multigraph<NoManagement, EVLManager>>>, ASABRError> {
     Ok(Rc::new(RefCell::new(Multigraph::new(ContactPlan::new(
         vec![
-            make_node(0, "source", NoManagement {}),
-            make_node(1, "from_C0", NoManagement {}),
-            make_node(2, "from_C2_C1", NoManagement {}),
-            make_node(3, "from_C3", NoManagement {}),
-            make_node(4, "from_C4", NoManagement {}),
+            make_vertex(0, "source", NoManagement {}),
+            make_vertex(1, "from_C0", NoManagement {}),
+            make_vertex(2, "from_C2_C1", NoManagement {}),
+            make_vertex(3, "from_C3", NoManagement {}),
+            make_vertex(4, "from_C4", NoManagement {}),
         ],
         vec![
             make_contact::<NoManagement>(0, 1, 0.0, 10.0, 1.0, 0.0),

--- a/src/pathfinding/test_helpers.rs
+++ b/src/pathfinding/test_helpers.rs
@@ -14,7 +14,9 @@ use crate::pathfinding::PathFindingOutput;
 use crate::route_stage::{RouteStage, SharedRouteStage};
 use crate::types::Date;
 use crate::vertex::Vertex;
+use crate::vnode::VirtualNodeMap;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 #[derive(Debug)]
@@ -271,4 +273,49 @@ pub(crate) fn make_hop_context(size: f64) -> HopContext<NoManagement> {
         source,
         nodes,
     }
+}
+
+/// Creates a graph with vnodes for testing anycast routing.
+///
+/// Topology (real nodes):
+///   A(0) --c0--> B(1) --c1--> C(2)
+///   A(0) --c2--> D(3) --c3--> E(4)
+///
+/// VNode V(5) labels both C(2) and E(4).
+///
+/// Contact c0: A->B, delay=1.0
+/// Contact c1: B->C, delay=1.0
+/// Contact c2: A->D, delay=0.5
+/// Contact c3: D->E, delay=0.5
+///
+/// Routing to V(5) should find the path A->D->E (arrival=1.01) over A->B->C (arrival=2.02)
+/// because E is reached faster and is part of the same vnode group.
+pub(crate) fn vnode_anycast_graph()
+-> Result<Rc<RefCell<Multigraph<NoManagement, EVLManager>>>, ASABRError> {
+    let mut vnode_to_rids_map_raw: HashMap<NodeID, Vec<NodeID>> = HashMap::new();
+    let mut rid_to_vnodes_map_raw: HashMap<NodeID, Vec<NodeID>> = HashMap::new();
+    vnode_to_rids_map_raw.insert(5, vec![2, 4]); // V(5) labels C(2) and E(4)
+    rid_to_vnodes_map_raw.insert(2, vec![5]);
+    rid_to_vnodes_map_raw.insert(4, vec![5]);
+
+    Ok(Rc::new(RefCell::new(Multigraph::new(ContactPlan::new(
+        vec![
+            make_vertex(0, "A", NoManagement {}),
+            make_vertex(1, "B", NoManagement {}),
+            make_vertex(2, "C", NoManagement {}),
+            make_vertex(3, "D", NoManagement {}),
+            make_vertex(4, "E", NoManagement {}),
+            Vertex::VNode(5), // VNode V
+        ],
+        vec![
+            make_contact::<NoManagement>(0, 1, 0.0, 2000.0, 100.0, 1.0), // c0: A->B, delay=1.0
+            make_contact::<NoManagement>(1, 2, 0.0, 2000.0, 100.0, 1.0), // c1: B->C, delay=1.0
+            make_contact::<NoManagement>(0, 3, 0.0, 2000.0, 100.0, 0.5), // c2: A->D, delay=0.5
+            make_contact::<NoManagement>(3, 4, 0.0, 2000.0, 100.0, 0.5), // c3: D->E, delay=0.5
+        ],
+        Some(VirtualNodeMap::new(
+            vnode_to_rids_map_raw,
+            rid_to_vnodes_map_raw,
+        )),
+    )?)?)))
 }

--- a/src/route_stage.rs
+++ b/src/route_stage.rs
@@ -154,8 +154,9 @@ impl<NM: NodeManager, CM: ContactManager> RouteStage<NM, CM> {
     ///
     /// This function schedules the transmission by interacting with the contact manager and the nodes
     /// in the `node_list`. If node management is enabled (features node_rx, node_tx, and node_proc),
-    /// the nodes will be queried for their transmission and reception schedules. The function will return `true`
-    /// if the scheduling is successful and the bundle is scheduled, or `false` if any failure occurs.
+    /// the nodes will be queried for their transmission and reception schedules. The function will
+    /// return Ok(()) if the scheduling is successful and the bundle is scheduled, or an error if
+    /// any failure occurs.
     ///
     /// # Arguments
     ///

--- a/src/route_stage.rs
+++ b/src/route_stage.rs
@@ -5,6 +5,7 @@ use crate::errors::ASABRError;
 use crate::node::Node;
 use crate::node_manager::NodeManager;
 use crate::types::{Date, Duration, HopCount, NodeID};
+use crate::vertex::VertexID;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -46,8 +47,8 @@ impl<NM: NodeManager, CM: ContactManager> Clone for ViaHop<NM, CM> {
 #[cfg_attr(feature = "debug", derive(derivative::Derivative))]
 #[cfg_attr(feature = "debug", derivative(Debug))]
 pub struct RouteStage<NM: NodeManager, CM: ContactManager> {
-    /// The ID of the destination node for this route stage.
-    pub to_node: NodeID,
+    /// The ID of the destination vertex for this route stage.
+    pub to_node: VertexID,
     /// The time at which this route stage is considered to be valid or relevant.
     pub at_time: Date,
     /// A flag that indicates if this stage of the route is disabled.

--- a/src/routing/aliases.rs
+++ b/src/routing/aliases.rs
@@ -174,7 +174,7 @@ pub struct SpsnOptions {
 
 pub fn build_generic_router<NM: NodeManager + 'static, CM: ContactManager + 'static>(
     router_type: &str,
-    contact_plan: ContactPlan<NM, NM, CM>,
+    contact_plan: ContactPlan<NM, CM>,
     spsn_options: Option<SpsnOptions>,
 ) -> Result<Box<dyn Router<NM, CM>>, ASABRError> {
     if let Some(options) = spsn_options {

--- a/src/routing/cgr.rs
+++ b/src/routing/cgr.rs
@@ -53,7 +53,7 @@ impl<S: RouteStorage<NM, CM>, NM: NodeManager, CM: ContactManager, P: Pathfindin
     Cgr<NM, CM, P, S>
 {
     pub fn new(
-        contact_plan: ContactPlan<NM, NM, CM>,
+        contact_plan: ContactPlan<NM, CM>,
         route_storage: Rc<RefCell<S>>,
     ) -> Result<Self, ASABRError> {
         Ok(Self {

--- a/src/routing/spsn.rs
+++ b/src/routing/spsn.rs
@@ -82,7 +82,7 @@ impl<S: TreeStorage<NM, CM>, NM: NodeManager, CM: ContactManager, P: Pathfinding
     ///
     /// * `Self` - A new instance of the `Spsn` struct.
     pub fn new(
-        contact_plan: ContactPlan<NM, NM, CM>,
+        contact_plan: ContactPlan<NM, CM>,
         route_storage: Rc<RefCell<S>>,
         with_priorities: bool,
     ) -> Result<Self, ASABRError> {

--- a/src/routing/volcgr.rs
+++ b/src/routing/volcgr.rs
@@ -57,7 +57,7 @@ impl<S: RouteStorage<NM, CM>, NM: NodeManager, CM: ContactManager, P: Pathfindin
     VolCgr<NM, CM, P, S>
 {
     pub fn new(
-        contact_plan: ContactPlan<NM, NM, CM>,
+        contact_plan: ContactPlan<NM, CM>,
         route_storage: Rc<RefCell<S>>,
     ) -> Result<Self, ASABRError> {
         Ok(Self {

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,36 +11,6 @@ pub type NodeID = u16;
 /// Represents a HashMap with node IDs as keys and node ID lists as values
 pub type NodeIDMap = HashMap<NodeID, Vec<NodeID>>;
 
-/// Represents a HashMap wich stores virtual node IDs as keys and real node ID lists as values
-#[derive(Debug, Default)]
-pub struct VirtualNodeMap {
-    vnode_map: NodeIDMap,
-}
-
-impl VirtualNodeMap {
-    pub fn new(vnode_map: HashMap<NodeID, Vec<NodeID>>) -> Self {
-        Self { vnode_map }
-    }
-
-    /// This method does no additional computations and returns reference to the stored NodeIDMap
-    pub fn get_vnode_to_rids_map(&self) -> &NodeIDMap {
-        &self.vnode_map
-    }
-
-    /// This method reverses the HashMap keys and values before returning a corresponding NodeIDMap
-    pub fn get_rid_to_vnodes_map(&self) -> NodeIDMap {
-        let mut reversed: HashMap<NodeID, Vec<NodeID>> = HashMap::new();
-
-        for (vnode, rids) in &self.vnode_map {
-            for rid in rids {
-                reversed.entry(*rid).or_default().push(*vnode);
-            }
-        }
-
-        reversed
-    }
-}
-
 /// Represents the name of a node.
 pub type NodeName = String;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, str::FromStr};
 
-use crate::parsing::{Lexer, ParsingState};
+use crate::{
+    errors::ASABRError,
+    parsing::{Lexer, LexerOutput},
+};
 
 // Convenient for vector indexing
 // TODO: add a check like ~ static_assert(sizeof(NodeID) <= sizeof(usize))
@@ -46,24 +49,28 @@ pub trait Token<T: Sized> {
     ///
     /// # Returns
     ///
-    /// A `ParsingState<T>` indicating the result of the parsing operation.
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<T>;
+    /// A `Result<LexerOutput<T>, ASABRError>` indicating the result of the parsing operation.
+    fn parse(lexer: &mut dyn Lexer) -> Result<T, ASABRError>;
 }
 
 /// Implement the `Token` trait for any type that implements `FromStr`.
 impl<T: FromStr> Token<T> for T {
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<T> {
-        let res = lexer.consume_next_token();
-        match res {
-            ParsingState::EOF => ParsingState::EOF,
-            ParsingState::Error(e) => ParsingState::Error(e),
-            ParsingState::Finished(token) => match token.parse::<T>() {
-                Ok(value) => ParsingState::Finished(value),
-                Err(_) => ParsingState::Error(format!(
-                    "Parsing failed ({})",
+    fn parse(lexer: &mut dyn Lexer) -> Result<T, ASABRError> {
+        let token = match lexer.consume_next_token()? {
+            LexerOutput::EOF => {
+                return Err(ASABRError::ParsingError(format!(
+                    "Expected token, found EOF ({})",
                     lexer.get_current_position()
-                )),
-            },
+                )));
+            }
+            LexerOutput::Finished(token) => token,
+        };
+        match token.parse::<T>() {
+            Ok(value) => Ok(value),
+            Err(_) => Err(ASABRError::ParsingError(format!(
+                "Parsing failed ({})",
+                lexer.get_current_position()
+            ))),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,7 +18,7 @@ pub type NodeName = String;
 pub type Duration = f64;
 
 /// Represents a date (could represent days since a specific epoch).
-pub type Date = f64;
+pub type Date = Duration;
 
 /// Represents the priority of a task or node.
 pub type Priority = i8;

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,12 +28,12 @@ impl VirtualNodeMap {
     }
 
     /// This method reverses the HashMap keys and values before returning a corresponding NodeIDMap
-    pub fn get_rid_to_vnodes_map(self) -> NodeIDMap {
+    pub fn get_rid_to_vnodes_map(&self) -> NodeIDMap {
         let mut reversed: HashMap<NodeID, Vec<NodeID>> = HashMap::new();
 
-        for (vnode, rids) in self.vnode_map {
+        for (vnode, rids) in &self.vnode_map {
             for rid in rids {
-                reversed.entry(rid).or_default().push(vnode);
+                reversed.entry(*rid).or_default().push(*vnode);
             }
         }
 

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -1,0 +1,67 @@
+use std::cmp::Ordering;
+
+use crate::{node::Node, node_manager::NodeManager, types::NodeID};
+
+/// Represents the unique inner identifier of a Vertex in the Multigraph.
+pub type VertexID = NodeID;
+
+/// Represents a vertex in the multigraph.
+/// In the case of an INode or ENode, this includes its associated manager, and they are wrapped
+/// in `Rc<RefCell<...>>` for shared ownership and mutability.
+///
+/// When sorted, INode and ENode are sorted by inner Node first, then INode < ENode.
+/// And VNode is always greatest. It is assumed that vnode IDs are assured to come after real node
+/// IDs from the contact plan parser.
+///
+/// # Type parameters
+/// - `NM`: A type implementing the `NodeManager` trait, responsible for managing the
+///   node's operations.
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub enum Vertex<NM: NodeManager> {
+    /// An interior node of the graph. Being interior, its contacts point both to it and to its
+    /// vnodes at Multigraph creation.
+    INode(Node<NM>),
+    /// An exterior node of the graph. Being exterior, its contacts only point to its vnodes at
+    /// Multigraph creation.
+    ENode(Node<NM>),
+    /// A virtual node. It is not a node, but an abstraction over one or more node. A "group",
+    /// "merger" or "contraction" of nodes.
+    /// Thus, it has no manager at all.
+    VNode(NodeID),
+}
+
+impl<NM: NodeManager> PartialEq for Vertex<NM> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::INode(a), Self::INode(b)) => a == b,
+            (Self::ENode(a), Self::ENode(b)) => a == b,
+            (Self::VNode(a), Self::VNode(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl<NM: NodeManager> Eq for Vertex<NM> {}
+
+impl<NM: NodeManager> Ord for Vertex<NM> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            // VNodes are always greater
+            (Self::VNode(a), Self::VNode(b)) => a.cmp(b),
+            (Self::VNode(_), _) => Ordering::Greater,
+            (_, Self::VNode(_)) => Ordering::Less,
+
+            // INode and ENode are sorted by inner Node first, then by variant (INode < ENode)
+            (Self::INode(a), Self::INode(b)) => a.cmp(b),
+            (Self::ENode(a), Self::ENode(b)) => a.cmp(b),
+            (Self::INode(a), Self::ENode(b)) => a.cmp(b).then(Ordering::Less),
+            (Self::ENode(a), Self::INode(b)) => a.cmp(b).then(Ordering::Greater),
+        }
+    }
+}
+
+impl<NM: NodeManager> PartialOrd for Vertex<NM> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/src/vnode.rs
+++ b/src/vnode.rs
@@ -57,7 +57,19 @@ impl Parser<VirtualNodeInfo> for VirtualNodeInfo {
 
         let rids_state = Vec::parse(lexer);
         let rids: Vec<NodeID> = match rids_state {
-            ParsingState::Finished(value) => value,
+            ParsingState::Finished(vec) => {
+                for i in 0..vec.len() {
+                    for j in (i + 1)..vec.len() {
+                        if vec[i] == vec[j] {
+                            return ParsingState::Error(format!(
+                                "Parsing failed: duplicate node ID in vnode definition ({})",
+                                lexer.get_current_position()
+                            ));
+                        }
+                    }
+                }
+                vec
+            }
             ParsingState::Error(msg) => return ParsingState::Error(msg),
             ParsingState::EOF => {
                 return ParsingState::Error(format!(
@@ -106,6 +118,7 @@ impl VirtualNodeMap {
     /// # Returns
     ///
     /// * `usize` - The total number of nodes.
+    #[inline(always)]
     pub fn get_vnode_count(&self) -> usize {
         self.vnode_map.len()
     }

--- a/src/vnode.rs
+++ b/src/vnode.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    parsing::{Lexer, Parser, ParsingState},
+    errors::ASABRError,
+    parsing::{Lexer, Parser},
     types::{NodeID, NodeIDMap, NodeName, Token},
 };
 
@@ -28,58 +29,26 @@ impl Parser<VirtualNodeInfo> for VirtualNodeInfo {
     ///
     /// # Returns
     ///
-    /// * `ParsingState<VirtualNodeInfo>` - The parsing state, which can be either finished with the parsed node info,
-    ///   an error, or an EOF state.
-    fn parse(lexer: &mut dyn Lexer) -> ParsingState<VirtualNodeInfo> {
-        let vid_state = NodeID::parse(lexer);
-        let vid: NodeID = match vid_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+    /// * `Result<LexerOutput<VirtualNodeInfo>, ASABRError>` - The parsing state, which can be either
+    ///   finished with the parsed node info, an error, or an EOF state.
+    fn parse(lexer: &mut dyn Lexer) -> Result<VirtualNodeInfo, ASABRError> {
+        let vid: NodeID = NodeID::parse(lexer)?;
 
-        let name_state = NodeName::parse(lexer);
-        let name: NodeName = match name_state {
-            ParsingState::Finished(value) => value,
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+        let name: NodeName = NodeName::parse(lexer)?;
 
-        let rids_state = Vec::parse(lexer);
-        let rids: Vec<NodeID> = match rids_state {
-            ParsingState::Finished(vec) => {
-                for i in 0..vec.len() {
-                    for j in (i + 1)..vec.len() {
-                        if vec[i] == vec[j] {
-                            return ParsingState::Error(format!(
-                                "Parsing failed: duplicate node ID in vnode definition ({})",
-                                lexer.get_current_position()
-                            ));
-                        }
-                    }
+        let rids: Vec<NodeID> = Vec::parse(lexer)?;
+        for i in 0..rids.len() {
+            for j in (i + 1)..rids.len() {
+                if rids[i] == rids[j] {
+                    return Err(ASABRError::ParsingError(format!(
+                        "Parsing failed: duplicate node ID in vnode definition ({})",
+                        lexer.get_current_position()
+                    )));
                 }
-                vec
             }
-            ParsingState::Error(msg) => return ParsingState::Error(msg),
-            ParsingState::EOF => {
-                return ParsingState::Error(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                ));
-            }
-        };
+        }
 
-        ParsingState::Finished(VirtualNodeInfo { vid, name, rids })
+        Ok(VirtualNodeInfo { vid, name, rids })
     }
 }
 

--- a/src/vnode.rs
+++ b/src/vnode.rs
@@ -95,7 +95,7 @@ impl VirtualNodeMap {
         Self { vnode_map }
     }
 
-    /// This method does no additional computations and returns reference to the stored NodeIDMap
+    /// This method does no additional computations and returns a reference to the stored NodeIDMap
     pub fn get_vnode_to_rids_map(&self) -> &NodeIDMap {
         &self.vnode_map
     }

--- a/src/vnode.rs
+++ b/src/vnode.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use crate::{
     parsing::{Lexer, Parser, ParsingState},
-    types::{NodeID, NodeName, Token},
+    types::{NodeID, NodeIDMap, NodeName, Token},
 };
 
 /// Represents information about a vnode in the network.
@@ -66,5 +68,35 @@ impl Parser<VirtualNodeInfo> for VirtualNodeInfo {
         };
 
         ParsingState::Finished(VirtualNodeInfo { vid, name, rids })
+    }
+}
+
+/// Represents a HashMap wich stores virtual node IDs as keys and real node ID lists as values
+#[derive(Debug, Default)]
+pub struct VirtualNodeMap {
+    vnode_map: NodeIDMap,
+}
+
+impl VirtualNodeMap {
+    pub fn new(vnode_map: HashMap<NodeID, Vec<NodeID>>) -> Self {
+        Self { vnode_map }
+    }
+
+    /// This method does no additional computations and returns reference to the stored NodeIDMap
+    pub fn get_vnode_to_rids_map(&self) -> &NodeIDMap {
+        &self.vnode_map
+    }
+
+    /// This method reverses the HashMap keys and values before returning a corresponding NodeIDMap
+    pub fn get_rid_to_vnodes_map(&self) -> NodeIDMap {
+        let mut reversed: HashMap<NodeID, Vec<NodeID>> = HashMap::new();
+
+        for (vnode, rids) in &self.vnode_map {
+            for rid in rids {
+                reversed.entry(*rid).or_default().push(*vnode);
+            }
+        }
+
+        reversed
     }
 }

--- a/src/vnode.rs
+++ b/src/vnode.rs
@@ -74,6 +74,7 @@ impl Parser<VirtualNodeInfo> for VirtualNodeInfo {
 /// Represents a HashMap wich stores virtual node IDs as keys and real node ID lists as values
 #[derive(Debug, Default)]
 pub struct VirtualNodeMap {
+    /// A vnode to nodes NodeIDMap.
     vnode_map: NodeIDMap,
 }
 
@@ -98,5 +99,14 @@ impl VirtualNodeMap {
         }
 
         reversed
+    }
+
+    /// Returns the total number of vnodes in the vnode map.
+    ///
+    /// # Returns
+    ///
+    /// * `usize` - The total number of nodes.
+    pub fn get_vnode_count(&self) -> usize {
+        self.vnode_map.len()
     }
 }

--- a/src/vnode.rs
+++ b/src/vnode.rs
@@ -56,30 +56,29 @@ impl Parser<VirtualNodeInfo> for VirtualNodeInfo {
 #[derive(Debug, Default)]
 pub struct VirtualNodeMap {
     /// A vnode to nodes NodeIDMap.
-    vnode_map: NodeIDMap,
+    vnode_to_rids_map: NodeIDMap,
+    rid_to_vnodes_map: NodeIDMap,
 }
 
 impl VirtualNodeMap {
-    pub fn new(vnode_map: HashMap<NodeID, Vec<NodeID>>) -> Self {
-        Self { vnode_map }
+    pub fn new(
+        vnode_to_rids_map: HashMap<NodeID, Vec<NodeID>>,
+        rids_to_vnode_map: HashMap<NodeID, Vec<NodeID>>,
+    ) -> Self {
+        Self {
+            vnode_to_rids_map,
+            rid_to_vnodes_map: rids_to_vnode_map,
+        }
     }
 
     /// This method does no additional computations and returns a reference to the stored NodeIDMap
     pub fn get_vnode_to_rids_map(&self) -> &NodeIDMap {
-        &self.vnode_map
+        &self.vnode_to_rids_map
     }
 
-    /// This method reverses the HashMap keys and values before returning a corresponding NodeIDMap
-    pub fn get_rid_to_vnodes_map(&self) -> NodeIDMap {
-        let mut reversed: HashMap<NodeID, Vec<NodeID>> = HashMap::new();
-
-        for (vnode, rids) in &self.vnode_map {
-            for rid in rids {
-                reversed.entry(*rid).or_default().push(*vnode);
-            }
-        }
-
-        reversed
+    /// This method does no additional computations and returns a reference to the stored NodeIDMap
+    pub fn get_rid_to_vnodes_map(&self) -> &NodeIDMap {
+        &self.rid_to_vnodes_map
     }
 
     /// Returns the total number of vnodes in the vnode map.
@@ -89,6 +88,6 @@ impl VirtualNodeMap {
     /// * `usize` - The total number of nodes.
     #[inline(always)]
     pub fn get_vnode_count(&self) -> usize {
-        self.vnode_map.len()
+        self.vnode_to_rids_map.len()
     }
 }


### PR DESCRIPTION
> To support routing with vnodes, we need outgoing contacts to vnodes (e.g. for anycast routing to vnode members).
This commit adds some sanity checks during `Multigraph` creation, and duplicates contacts that point to rnodes of a vnode, so that they point also to the vnode.

Okay so, I'm not very happy about this commit. The checks are too expensive, I think. I added them in case someone meddles with the `ContactPlan` between parsing and `Multigraph` creation.
Should I leave them?

Secondly, it doesn't build. I feel that I'm doing something too hacky here, that it's not the right solution, I'm not sure.
I want to duplicate contacts that point to a Rx rnode, to point also to the vnode, as Rx. However that means I need to make `Contact`s, `NodeManagers`, and maybe more `Clone`able, in my approach.
But is my approach the right one?

---

Afterwards, for routing, there will have to be a *check* to see if it's a vnode that we are routing to. If that's the case, only anycast should be allowed.
This *check* could be performed in three ways: check that the node is a vnode using the vnode_map, check using the range of the vnode ID compared to the max rid (I have to make sure the ranges are respected), or using a boolean flag that indicates if a node is a vnode.
Second one is best, but I have to check if the vid range is always after the rid range. I see there's some sorting in the Multigraph.

---

### Update: unstuck, see comments below.