### PR TITLE
Added legacy contact manager tests 

### DIFF
--- a/src/contact_manager/legacy/eto.rs
+++ b/src/contact_manager/legacy/eto.rs
@@ -33,4 +33,58 @@ mod tests {
 
     crate::generate_common_tests!(eto, ETOManager);
     crate::generate_budget_tests!(pbeto);
+
+    #[test]
+    fn schedule_tx_does_not_consume_volume() {
+        let mut manager = eto();
+        let contact = make_contact_info(C_START, C_END);
+        for i in 0..20 {
+            assert!(
+                manager
+                    .schedule_tx(&contact, C_START, &bp0(1000.0))
+                    .is_some(),
+                "TEST FAILED: ETO schedule_tx should never saturate (call {}).",
+                i + 1
+            );
+        }
+    }
+
+    #[test]
+    fn schedule_tx_always_returns_same_result() {
+        let mut manager = eto();
+        let contact = make_contact_info(C_START, C_END);
+        let bundle = bp0(1000.0);
+        let first = manager.schedule_tx(&contact, C_START, &bundle);
+        let second = manager.schedule_tx(&contact, C_START, &bundle);
+
+        assert_eq!(
+            first, second,
+            "TEST FAILED: ETO schedule_tx should return identical results since queue is never updated."
+        );
+    }
+
+    #[cfg(feature = "manual_queueing")]
+    #[test]
+    fn manual_enqueue_shifts_tx_start_from_at_time() {
+        let mut manager = eto();
+        let contact = make_contact_info(C_START, C_END);
+        manager.manual_enqueue(&bp0(2000.0));
+        let data = manager.dry_run_tx(&contact, 3.0, &bp0(100.0)).unwrap();
+        assert_eq!(
+            data.tx_start, 5.0,
+            "TEST FAILED: tx_start should be at_time + queue/rate for ETO."
+        );
+    }
+
+    #[cfg(feature = "manual_queueing")]
+    #[test]
+    fn manual_enqueue_shift_can_push_past_contact_end() {
+        let mut manager = eto();
+        let contact = make_contact_info(C_START, C_END);
+        manager.manual_enqueue(&bp0(9900.0));
+        assert!(
+            manager.dry_run_tx(&contact, C_START, &bp0(200.0)).is_none(),
+            "TEST FAILED: Bundle should not fit when manual queue shift pushes tx_end past contact end."
+        );
+    }
 }

--- a/src/contact_manager/legacy/eto.rs
+++ b/src/contact_manager/legacy/eto.rs
@@ -8,3 +8,29 @@ generate_prio_volume_manager!(ETOManager, true, false, 1, false);
 generate_prio_volume_manager!(PETOManager, true, false, 3, false);
 // with priorities (3 levels) and maximum budgets per level
 generate_prio_volume_manager!(PBETOManager, true, false, 3, true);
+
+#[cfg(test)]
+mod tests {
+    use super::{ETOManager, PBETOManager, PETOManager};
+    use crate::contact_manager::ContactManager;
+    use crate::contact_manager::legacy::test_helpers::*;
+
+    fn eto() -> ETOManager {
+        let mut manager = ETOManager::new(RATE, DELAY);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+    fn _peto() -> PETOManager {
+        let mut manager = PETOManager::new(RATE, DELAY);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+    fn pbeto() -> PBETOManager {
+        let mut manager = PBETOManager::new(RATE, DELAY, [BUDGET_P0, BUDGET_P1, BUDGET_P2]);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+
+    crate::generate_common_tests!(eto, ETOManager);
+    crate::generate_budget_tests!(pbeto);
+}

--- a/src/contact_manager/legacy/evl.rs
+++ b/src/contact_manager/legacy/evl.rs
@@ -8,3 +8,31 @@ generate_prio_volume_manager!(EVLManager, false, true, 1, false);
 generate_prio_volume_manager!(PEVLManager, false, true, 3, false);
 // with priorities (3 levels) and maximum budgets per level
 generate_prio_volume_manager!(PBEVLManager, false, true, 3, true);
+
+#[cfg(test)]
+mod tests {
+    use super::{EVLManager, PBEVLManager, PEVLManager};
+    use crate::contact_manager::ContactManager;
+    use crate::contact_manager::legacy::test_helpers::*;
+
+    fn evl() -> EVLManager {
+        let mut manager = EVLManager::new(RATE, DELAY);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+    fn pevl() -> PEVLManager {
+        let mut manager = PEVLManager::new(RATE, DELAY);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+    fn pbevl() -> PBEVLManager {
+        let mut manager = PBEVLManager::new(RATE, DELAY, [BUDGET_P0, BUDGET_P1, BUDGET_P2]);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+
+    crate::generate_common_tests!(evl, EVLManager);
+    crate::generate_auto_update_tests!(evl, pevl);
+    crate::generate_budget_tests!(pbevl);
+    crate::generate_budget_auto_update_tests!(pbevl);
+}

--- a/src/contact_manager/legacy/evl.rs
+++ b/src/contact_manager/legacy/evl.rs
@@ -35,4 +35,27 @@ mod tests {
     crate::generate_auto_update_tests!(evl, pevl);
     crate::generate_budget_tests!(pbevl);
     crate::generate_budget_auto_update_tests!(pbevl);
+
+    #[test]
+    fn tx_start_unaffected_by_queue_occupancy() {
+        let mut manager = evl();
+        let contact = make_contact_info(C_START, C_END);
+        let before = manager.dry_run_tx(&contact, C_START, &bp0(1000.0)).unwrap();
+        manager
+            .schedule_tx(&contact, C_START, &bp0(1000.0))
+            .unwrap();
+        manager
+            .schedule_tx(&contact, C_START, &bp0(1000.0))
+            .unwrap();
+        manager
+            .schedule_tx(&contact, C_START, &bp0(1000.0))
+            .unwrap();
+
+        let after = manager.dry_run_tx(&contact, C_START, &bp0(1000.0)).unwrap();
+
+        assert_eq!(
+            before.tx_start, after.tx_start,
+            "TEST FAILED: EVL tx_start should not be affected by queue occupancy."
+        );
+    }
 }

--- a/src/contact_manager/legacy/mod.rs
+++ b/src/contact_manager/legacy/mod.rs
@@ -2,6 +2,9 @@ pub mod eto;
 pub mod evl;
 pub mod qd;
 
+#[cfg(test)]
+pub(crate) mod test_helpers;
+
 /// Generates a legacy volume management structure and a part of its implementation based on the provided parameters. This
 /// macro is called by the generate_prio_volume_manager macro.
 ///
@@ -107,18 +110,18 @@ macro_rules! generate_struct_management {
 
             #[inline(always)]
             fn get_queue_size(&self, bundle: &$crate::bundle::Bundle) -> $crate::types::Volume {
-                    self.queue_size[bundle.priority as usize]
+                    self.queue_size[(bundle.priority as usize).min($prio_count - 1)]
             }
             #[inline(always)]
             fn enqueue(&mut self, bundle: &$crate::bundle::Bundle)  {
-                for prio in 0..bundle.priority as usize + 1 {
+                for prio in 0..(bundle.priority as usize + 1).min($prio_count) {
                     self.queue_size[prio] += bundle.size;
                 }
             }
             #[allow(dead_code)]
             #[inline(always)]
             fn dequeue(&mut self, bundle: &$crate::bundle::Bundle)  {
-                for prio in 0..bundle.priority as usize + 1 {
+                for prio in 0..(bundle.priority as usize + 1).min($prio_count) {
                     self.queue_size[prio] -= bundle.size;
                 }
             }
@@ -173,30 +176,29 @@ macro_rules! generate_struct_management {
 
             #[inline(always)]
             fn get_queue_size(&self, bundle: &$crate::bundle::Bundle) -> $crate::types::Volume {
-                    self.queue_size[bundle.priority as usize]
+                    self.queue_size[(bundle.priority as usize).min($prio_count - 1)]
             }
             #[inline(always)]
             fn enqueue(&mut self, bundle: &$crate::bundle::Bundle)  {
-                for prio in 0..bundle.priority as usize + 1 {
+                for prio in 0..(bundle.priority as usize + 1).min($prio_count) {
                     self.queue_size[prio] += bundle.size;
                 }
             }
             #[allow(dead_code)]
             #[inline(always)]
             fn dequeue(&mut self, bundle: &$crate::bundle::Bundle)  {
-                for prio in 0..bundle.priority as usize + 1 {
+                for prio in 0..(bundle.priority as usize + 1).min($prio_count) {
                     self.queue_size[prio] -= bundle.size;
                 }
             }
             #[inline(always)]
             fn get_budget(&self, bundle: &$crate::bundle::Bundle) -> $crate::types::Volume  {
-               return self.budgets[bundle.priority as usize];
+               return self.budgets[(bundle.priority as usize).min($prio_count - 1)];
             }
             #[inline(always)]
             fn build_parsing_output(rate: $crate::types::DataRate, delay: $crate::types::Duration, lexer: &mut dyn $crate::parsing::Lexer) -> Result<Self, $crate::errors::ASABRError>{
-                let mut budgets = [0.0; 3];
+                let mut budgets = [0.0; $prio_count];
                 for i in 0..$prio_count {
-
                     let budget = <$crate::types::Volume as $crate::types::Token<$crate::types::Volume>>::parse(lexer)?;
                     budgets[i] = budget;
                 }
@@ -314,7 +316,7 @@ macro_rules! generate_prio_volume_manager {
             #[doc = concat!( "The queue volume will be updated by this method: ", stringify!($auto_update),"`.")]
             /// # Arguments
             ///
-            /// * `contact_data` - Reference to the contact information (unused in this implementation).
+            /// * `contact_data` - Reference to the contact information.
             /// * `at_time` - The current time for scheduling purposes.
             /// * `bundle` - The bundle to be transmitted.
             ///

--- a/src/contact_manager/legacy/qd.rs
+++ b/src/contact_manager/legacy/qd.rs
@@ -35,4 +35,53 @@ mod tests {
     crate::generate_auto_update_tests!(qd, pqd);
     crate::generate_budget_tests!(pbqd);
     crate::generate_budget_auto_update_tests!(pbqd);
+
+    #[test]
+    fn queue_delay_shifts_tx_start_from_contact_start() {
+        let mut manager = qd();
+        let contact = make_contact_info(C_START, C_END);
+
+        // 2000 bytes schedulés → queue_size/rate = 2000/1000 = 2s de décalage
+        manager
+            .schedule_tx(&contact, C_START, &bp0(2000.0))
+            .unwrap();
+
+        // at_time=0 < contact_start décalé (2.0) → tx_start doit être 2.0
+        let data = manager.dry_run_tx(&contact, C_START, &bp0(100.0)).unwrap();
+        assert_eq!(
+            data.tx_start, 2.0,
+            "TEST FAILED: tx_start should be shifted by queue delay from contact start."
+        );
+    }
+
+    #[test]
+    fn late_arriving_bundle_ignores_queue_shift() {
+        let mut manager = qd();
+        let contact = make_contact_info(C_START, C_END);
+
+        // queue décale contact_start à 2.0
+        manager
+            .schedule_tx(&contact, C_START, &bp0(2000.0))
+            .unwrap();
+
+        // at_time=5.0 > 2.0 → tx_start doit être at_time, pas le décalage
+        let data = manager.dry_run_tx(&contact, 5.0, &bp0(100.0)).unwrap();
+        assert_eq!(
+            data.tx_start, 5.0,
+            "TEST FAILED: tx_start should be at_time when it arrives after the queue shift."
+        );
+    }
+
+    #[test]
+    fn queue_shift_can_push_bundle_past_contact_end() {
+        let mut manager = qd();
+        let contact = make_contact_info(C_START, C_END);
+        manager
+            .schedule_tx(&contact, C_START, &bp0(9900.0))
+            .unwrap();
+        assert!(
+            manager.dry_run_tx(&contact, C_START, &bp0(200.0)).is_none(),
+            "TEST FAILED: Bundle should not fit when queue shift pushes tx_end past contact end."
+        );
+    }
 }

--- a/src/contact_manager/legacy/qd.rs
+++ b/src/contact_manager/legacy/qd.rs
@@ -41,12 +41,10 @@ mod tests {
         let mut manager = qd();
         let contact = make_contact_info(C_START, C_END);
 
-        // 2000 bytes schedulés → queue_size/rate = 2000/1000 = 2s de décalage
         manager
             .schedule_tx(&contact, C_START, &bp0(2000.0))
             .unwrap();
 
-        // at_time=0 < contact_start décalé (2.0) → tx_start doit être 2.0
         let data = manager.dry_run_tx(&contact, C_START, &bp0(100.0)).unwrap();
         assert_eq!(
             data.tx_start, 2.0,
@@ -59,12 +57,10 @@ mod tests {
         let mut manager = qd();
         let contact = make_contact_info(C_START, C_END);
 
-        // queue décale contact_start à 2.0
         manager
             .schedule_tx(&contact, C_START, &bp0(2000.0))
             .unwrap();
 
-        // at_time=5.0 > 2.0 → tx_start doit être at_time, pas le décalage
         let data = manager.dry_run_tx(&contact, 5.0, &bp0(100.0)).unwrap();
         assert_eq!(
             data.tx_start, 5.0,

--- a/src/contact_manager/legacy/qd.rs
+++ b/src/contact_manager/legacy/qd.rs
@@ -7,4 +7,32 @@ generate_prio_volume_manager!(QDManager, true, true, 1, false);
 // with priorities (3 levels)
 generate_prio_volume_manager!(PQDManager, true, true, 3, false);
 // with priorities (3 levels) and maximum budgets per level
-generate_prio_volume_manager!(PBQDManager, true, true, 3, false);
+generate_prio_volume_manager!(PBQDManager, true, true, 3, true);
+
+#[cfg(test)]
+mod tests {
+    use super::{PBQDManager, PQDManager, QDManager};
+    use crate::contact_manager::ContactManager;
+    use crate::contact_manager::legacy::test_helpers::*;
+
+    fn qd() -> QDManager {
+        let mut manager = QDManager::new(RATE, DELAY);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+    fn pqd() -> PQDManager {
+        let mut manager = PQDManager::new(RATE, DELAY);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+    fn pbqd() -> PBQDManager {
+        let mut manager = PBQDManager::new(RATE, DELAY, [BUDGET_P0, BUDGET_P1, BUDGET_P2]);
+        manager.try_init(&make_contact_info(C_START, C_END));
+        manager
+    }
+
+    crate::generate_common_tests!(qd, QDManager);
+    crate::generate_auto_update_tests!(qd, pqd);
+    crate::generate_budget_tests!(pbqd);
+    crate::generate_budget_auto_update_tests!(pbqd);
+}

--- a/src/contact_manager/legacy/test_helpers.rs
+++ b/src/contact_manager/legacy/test_helpers.rs
@@ -1,0 +1,285 @@
+use crate::bundle::Bundle;
+use crate::contact::ContactInfo;
+use crate::types::{DataRate, Date, Duration, Volume};
+
+pub(crate) const RATE: DataRate = 1000.0;
+pub(crate) const DELAY: Duration = 1.0;
+pub(crate) const C_START: Date = 0.0;
+pub(crate) const C_END: Date = 10.0;
+pub(crate) const TOTAL_VOL: Volume = 10000.0;
+pub(crate) const BUDGET_P0: Volume = 2000.0;
+pub(crate) const BUDGET_P1: Volume = 5000.0;
+pub(crate) const BUDGET_P2: Volume = TOTAL_VOL;
+
+pub(crate) fn make_contact_info(start: Date, end: Date) -> ContactInfo {
+    ContactInfo::new(0, 1, start, end)
+}
+
+pub(crate) fn make_bundle(size: Volume, priority: i8) -> Bundle {
+    Bundle {
+        source: 0,
+        destinations: vec![1],
+        priority,
+        size,
+        expiration: 99999.0,
+    }
+}
+
+pub(crate) fn bp0(size: Volume) -> Bundle {
+    make_bundle(size, 0)
+}
+pub(crate) fn bp1(size: Volume) -> Bundle {
+    make_bundle(size, 1)
+}
+pub(crate) fn bp2(size: Volume) -> Bundle {
+    make_bundle(size, 2)
+}
+
+#[macro_export]
+macro_rules! generate_common_tests {
+    ($manager_fn:expr, $manager_type:ty) => {
+        #[test]
+        fn try_init_zero_duration_rejects_any_bundle() {
+            let mut manager = <$manager_type>::new(RATE, DELAY);
+            let contact = $crate::contact::ContactInfo::new(0, 1, 5.0, 5.0);
+            manager.try_init(&contact);
+            assert!(
+                manager.dry_run_tx(&contact, 5.0, &bp0(1.0)).is_none(),
+                "TEST FAILED: Expected None for a contact with a duration of zero."
+            );
+        }
+
+        #[test]
+        fn dry_run_volume_boundary() {
+            let manager = ($manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            assert!(
+                manager.dry_run_tx(&contact, C_START, &bp0(TOTAL_VOL)).is_some(),
+                "TEST FAILED: Expected Some at exact volume boundary."
+            );
+            assert!(
+                manager.dry_run_tx(&contact, C_START, &bp0(TOTAL_VOL + 1.0)).is_none(),
+                "TEST FAILED: Expected None above volume boundary."
+            );
+        }
+
+        #[test]
+        fn dry_run_contact_timing_boundaries() {
+            let manager = ($manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            assert!(
+                manager.dry_run_tx(&contact, C_END + 1.0, &bp0(1.0)).is_none(),
+                "TEST FAILED: Expected None when at_time is past contact end."
+            );
+            assert!(
+                manager.dry_run_tx(&contact, C_END - 0.5, &bp0(600.0)).is_none(),
+                "TEST FAILED: Expected None when bundle does not fit in remaining time."
+            );
+        }
+
+        #[test]
+        fn dry_run_makes_same_results() {
+            let manager = ($manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            let bundle = bp0(100.0);
+            assert_eq!(
+                manager.dry_run_tx(&contact, C_START, &bundle),
+                manager.dry_run_tx(&contact, C_START, &bundle),
+                "TEST FAILED: dry_run_tx should make the same results each time."
+            );
+        }
+
+        #[test]
+        fn tx_data_fields_are_correct() {
+            let data = ($manager_fn)()
+                .dry_run_tx(&make_contact_info(C_START, C_END), C_START, &bp0(100.0))
+                .unwrap();
+            assert_eq!(
+                data.expiration,
+                C_END,
+                "TEST FAILED: expiration should equal C_END."
+            );
+            assert_eq!(
+                data.rx_start,
+                data.tx_start + DELAY,
+                "TEST FAILED: rx_start should equal tx_start + DELAY."
+            );
+             assert_eq!(
+                data.rx_end,
+                data.tx_end + DELAY,
+                "TEST FAILED: rx_end should equal tx_end + DELAY."
+            );
+        }
+
+        #[test]
+        fn schedule_tx_matches_dry_run_on_fresh_manager() {
+            let manager_dry = ($manager_fn)();
+            let mut manager_sched = ($manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            let bundle = bp0(100.0);
+            assert_eq!(
+                manager_dry.dry_run_tx(&contact, C_START, &bundle),
+                manager_sched.schedule_tx(&contact, C_START, &bundle),
+                "TEST FAILED: schedule_tx and dry_run_tx should return identical timings on a fresh manager."
+            );
+        }
+
+        #[test]
+        fn single_prio_manager_ignores_priority_field() {
+            let manager = ($manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            assert_eq!(
+                manager.dry_run_tx(&contact, C_START, &bp0(100.0)),
+                manager.dry_run_tx(&contact, C_START, &bp1(100.0)),
+                "TEST FAILED: Single-priority manager should return identical timings for p0 and p1."
+            );
+            assert_eq!(
+                manager.dry_run_tx(&contact, C_START, &bp0(100.0)),
+                manager.dry_run_tx(&contact, C_START, &bp2(100.0)),
+                "TEST FAILED: Single-priority manager should return identical timings for p0 and p2."
+            );
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! generate_auto_update_tests {
+    ($manager_fn:expr, $p_manager_fn:expr) => {
+        #[test]
+        fn schedule_tx_saturation() {
+            let mut manager = ($manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            for i in 0..10 {
+                assert!(
+                    manager
+                        .schedule_tx(&contact, C_START, &bp0(1000.0))
+                        .is_some(),
+                    "TEST FAILED: Expected Some on schedule {} of 10.",
+                    i + 1
+                );
+            }
+            assert!(
+                manager.schedule_tx(&contact, C_START, &bp0(0.1)).is_none(),
+                "TEST FAILED: Expected None after volume is fully saturated."
+            );
+        }
+
+        #[test]
+        fn priority_cascade_and_isolation() {
+            let mut manager = ($p_manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            assert!(
+                manager
+                    .schedule_tx(&contact, C_START, &bp2(5000.0))
+                    .is_some(),
+                "TEST FAILED: Expected Some scheduling p2 bundle."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp0(5000.0))
+                    .is_some(),
+                "TEST FAILED: Expected Some for p0 bundle within remaining p0 budget."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp0(5001.0))
+                    .is_none(),
+                "TEST FAILED: Expected None for p0 bundle exceeding remaining p0 budget (cascade)."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp2(TOTAL_VOL - 5000.0))
+                    .is_some(),
+                "TEST FAILED: Expected Some for p2 bundle within remaining global volume."
+            );
+        }
+
+        #[test]
+        fn mid_prio_cascades_down_but_not_up() {
+            let mut manager = ($p_manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            assert!(
+                manager
+                    .schedule_tx(&contact, C_START, &bp1(5000.0))
+                    .is_some(),
+                "TEST FAILED: Expected Some scheduling p1 bundle."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp0(5001.0))
+                    .is_none(),
+                "TEST FAILED: Expected None for p0 -> p1 cascade should have consumed p0 budget."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp2(TOTAL_VOL))
+                    .is_some(),
+                "TEST FAILED: Expected Some for p2 -> p1 should not cascade upward."
+            );
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! generate_budget_tests {
+    ($pb_manager_fn:expr) => {
+        #[test]
+        fn budget_hard_limits_per_priority() {
+            let manager = ($pb_manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp0(BUDGET_P0))
+                    .is_some(),
+                "TEST FAILED: Expected Some for p0 bundle at exact budget."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp0(BUDGET_P0 + 0.1))
+                    .is_none(),
+                "TEST FAILED: Expected None for p0 bundle exceeding budget."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp1(BUDGET_P1))
+                    .is_some(),
+                "TEST FAILED: Expected Some for p1 bundle at exact budget."
+            );
+            assert!(
+                manager
+                    .dry_run_tx(&contact, C_START, &bp1(BUDGET_P1 + 0.1))
+                    .is_none(),
+                "TEST FAILED: Expected None for p1 bundle exceeding budget."
+            );
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! generate_budget_auto_update_tests {
+    ($pb_manager_fn:expr) => {
+        #[test]
+        fn budget_priorities_are_independent() {
+            let mut manager = ($pb_manager_fn)();
+            let contact = make_contact_info(C_START, C_END);
+            assert!(
+                manager
+                    .schedule_tx(&contact, C_START, &bp0(BUDGET_P0))
+                    .is_some(),
+                "TEST FAILED: Expected Some scheduling p0 bundle up to its budget."
+            );
+            assert!(
+                manager.dry_run_tx(&contact, C_START, &bp0(0.1)).is_none(),
+                "TEST FAILED: Expected None -> p0 budget should be exhausted."
+            );
+            assert!(
+                manager.dry_run_tx(&contact, C_START, &bp2(100.0)).is_some(),
+                "TEST FAILED: Expected Some -> p2 budget should be independent of p0."
+            );
+            assert!(
+                manager.dry_run_tx(&contact, C_START, &bp1(1.0)).is_some(),
+                "TEST FAILED: Expected Some -> p1 budget should be independent of p0."
+            );
+        }
+    };
+}


### PR DESCRIPTION
Added: 
- common tests shared in the legacy contact manager implementations (EVL, QD, ETO) with macros in test_helpers
- specifics tests for each of them implementations

Fixed: 
- the main macro in legacy/mod.rs should no longer panic when used with a priority count other than 3 
- managers that don't support priorities will treat a prioritized bundles as unprioritized ones