### PR TITLE
add specific CP parsing error to `main()`

### DIFF
--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -2,6 +2,7 @@ use crate::{
     contact::{Contact, ContactInfo},
     contact_manager::ContactManager,
     contact_plan::ContactPlan,
+    errors::{ASABRError, CowError},
     node::{Node, NodeInfo},
     parsing::{Parser, StaticMarkerMap},
     types::{NodeID, NodeIDMap, NodeName, VirtualNodeMap},
@@ -35,17 +36,17 @@ impl ASABRContactPlan {
         contacts: &mut Vec<Contact<NM, CM>>,
         vnode_map: &NodeIDMap,
         max_node_id_in_contacts: &mut usize,
-    ) -> Result<(), String> {
+    ) -> Result<(), ASABRError> {
         if vnode_map.contains_key(&contact.info.rx_node) {
-            return Err(format!(
+            return Err(ASABRError::ParsingError(CowError::new(format!(
                 "Contact Rx node ({}) cannot be a virtual node",
                 contact.info.rx_node
-            ));
+            ))));
         } else if vnode_map.contains_key(&contact.info.tx_node) {
-            return Err(format!(
+            return Err(ASABRError::ParsingError(CowError::new(format!(
                 "Contact Tx node ({}) cannot be a virtual node",
                 contact.info.tx_node
-            ));
+            ))));
         }
 
         let value = max(contact.get_tx_node(), contact.get_rx_node());
@@ -64,7 +65,7 @@ impl ASABRContactPlan {
     ///
     /// # Returns
     ///
-    /// * `Result<(), String>` - Returns `Ok(())` if the node was successfully added, or an error message
+    /// * `Result<(), ASABRError>` - Returns `Ok(())` if the node was successfully added, or an error message
     ///   if there is a conflict with an existing node ID or name.
     ///
     /// # Type Parameters
@@ -76,15 +77,19 @@ impl ASABRContactPlan {
         max_node_id_in_nodes: &mut usize,
         known_node_ids: &mut HashSet<NodeID>,
         known_node_names: &mut HashSet<NodeName>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ASABRError> {
         let node_id = node.get_node_id();
         let node_name = node.get_node_name();
 
         if known_node_ids.contains(&node_id) {
-            return Err(format!("Two nodes have the same id ({node_id})"));
+            return Err(ASABRError::ParsingError(CowError::new(format!(
+                "Two nodes have the same id ({node_id})"
+            ))));
         }
         if known_node_names.contains(&node_name) {
-            return Err(format!("Two nodes have the same name ({node_name})"));
+            return Err(ASABRError::ParsingError(CowError::new(format!(
+                "Two nodes have the same name ({node_name})"
+            ))));
         }
         *max_node_id_in_nodes = max(*max_node_id_in_nodes, node_id.into());
         known_node_ids.insert(node_id);
@@ -104,14 +109,14 @@ impl ASABRContactPlan {
     ///
     /// # Returns
     ///
-    /// * `Result<(), String>` - Returns `Ok(())` if the node was successfully added, or an error message
+    /// * `Result<(), ASABRError>` - Returns `Ok(())` if the node was successfully added, or an error message
     ///   if any of the error control checks fail.
     fn add_vnode(
         vnode_info: VirtualNodeInfo,
         vnode_map: &mut NodeIDMap,
         known_node_ids: &HashSet<NodeID>,
         max_node_id_in_nodes: &mut usize,
-    ) -> Result<(), String> {
+    ) -> Result<(), ASABRError> {
         // Error control checks
         // 1. A vnode ID must come after all the real node IDs it references.
 
@@ -121,29 +126,29 @@ impl ASABRContactPlan {
         let max_real_node_id = (*max_node_id_in_nodes - 1) - vnode_map.len();
 
         if usize::from(vnode_info.vid) <= max_real_node_id {
-            return Err(format!(
+            return Err(ASABRError::ParsingError(CowError::new(format!(
                 "Virtual node ID is in the range of its real node IDs (vid {} <= {})",
                 vnode_info.vid, max_real_node_id
-            ));
+            ))));
         }
 
         // 2. A vnode's rids mut be in range and must not be duplicates.
         let mut known_rids: HashSet<NodeID> = HashSet::new();
         for rid in &vnode_info.rids {
             if usize::from(*rid) > max_real_node_id {
-                return Err(format!(
+                return Err(ASABRError::ParsingError(CowError::new(format!(
                     "Node ID out of range ({rid} > {max_real_node_id}) in virtual node definition"
-                ));
+                ))));
             }
             if !known_node_ids.contains(rid) {
-                return Err(format!(
+                return Err(ASABRError::ParsingError(CowError::new(format!(
                     "Node ID referenced in in virtual node definition does not exist ({rid})"
-                ));
+                ))));
             }
             if known_rids.contains(rid) {
-                return Err(format!(
+                return Err(ASABRError::ParsingError(CowError::new(format!(
                     "Node ID duplicate ({rid}) in virtual node definition"
-                ));
+                ))));
             }
             known_rids.insert(*rid);
         }
@@ -168,7 +173,7 @@ impl ASABRContactPlan {
     ///
     /// # Returns
     ///
-    /// * `Result<ContactPlan<NM, NM, CM>, String>` - Returns a `ContactPlan` containing vectors of parsed
+    /// * `Result<ContactPlan<NM, NM, CM>, ASABRError>` - Returns a `ContactPlan` containing vectors of parsed
     ///   nodes and contacts, or an error message if there is an issue during parsing.
     ///
     /// # Type Parameters
@@ -184,7 +189,7 @@ impl ASABRContactPlan {
         lexer: &mut dyn Lexer,
         node_marker_map: Option<&StaticMarkerMap<NM>>,
         contact_marker_map: Option<&StaticMarkerMap<CM>>,
-    ) -> Result<ContactPlan<NM, NM, CM>, String> {
+    ) -> Result<ContactPlan<NM, NM, CM>, ASABRError> {
         let mut contacts: Vec<Contact<NM, CM>> = Vec::new();
         let mut nodes: Vec<Node<NM>> = Vec::new();
         let mut vnode_map: NodeIDMap = NodeIDMap::new();
@@ -203,7 +208,7 @@ impl ASABRContactPlan {
                     break;
                 }
                 ParsingState::Error(msg) => {
-                    return Err(msg);
+                    return Err(ASABRError::ParsingError(CowError::new(msg)));
                 }
                 ParsingState::Finished(element_type) => match element_type.as_str() {
                     "contact" => {
@@ -214,14 +219,14 @@ impl ASABRContactPlan {
                                 break;
                             }
                             ParsingState::Error(msg) => {
-                                return Err(msg);
+                                return Err(ASABRError::ParsingError(CowError::new(msg)));
                             }
                             ParsingState::Finished((info, manager)) => {
                                 let Some(contact) = Contact::try_new(info, manager) else {
-                                    return Err(format!(
+                                    return Err(ASABRError::ParsingError(CowError::new(format!(
                                         "Malformed contact ({})",
                                         lexer.get_current_position()
-                                    ));
+                                    ))));
                                 };
 
                                 Self::add_contact(
@@ -240,14 +245,14 @@ impl ASABRContactPlan {
                                 break;
                             }
                             ParsingState::Error(msg) => {
-                                return Err(msg);
+                                return Err(ASABRError::ParsingError(CowError::new(msg)));
                             }
                             ParsingState::Finished((info, manager)) => {
                                 let Some(node) = Node::try_new(info, manager) else {
-                                    return Err(format!(
+                                    return Err(ASABRError::ParsingError(CowError::new(format!(
                                         "Malformed node ({})",
                                         lexer.get_current_position()
-                                    ));
+                                    ))));
                                 };
 
                                 Self::add_node(
@@ -267,7 +272,7 @@ impl ASABRContactPlan {
                                 break;
                             }
                             ParsingState::Error(msg) => {
-                                return Err(msg);
+                                return Err(ASABRError::ParsingError(CowError::new(msg)));
                             }
                             ParsingState::Finished((info, manager)) => {
                                 // A vnode is not only a mapping to a list of NodeIDs in a vnode_map, it is also a real node in the graph.
@@ -279,10 +284,10 @@ impl ASABRContactPlan {
                                 };
 
                                 let Some(vnode) = Node::try_new(node_info, manager) else {
-                                    return Err(format!(
+                                    return Err(ASABRError::ParsingError(CowError::new(format!(
                                         "Malformed node ({})",
                                         lexer.get_current_position()
-                                    ));
+                                    ))));
                                 };
 
                                 // Add the vnode to the nodes list, returning on error.
@@ -309,28 +314,30 @@ impl ASABRContactPlan {
                         }
                     }
                     _ => {
-                        return Err(format!(
+                        return Err(ASABRError::ParsingError(CowError::new(format!(
                             "Unrecognized CP element ({})",
                             lexer.get_current_position()
-                        ));
+                        ))));
                     }
                 },
             }
         }
         if vnode_map.is_empty() && (max_node_id_in_contacts != max_node_id_in_nodes) {
-            return Err(
-                "The max node numbers for the contact and node definitions do not match"
-                    .to_string(),
-            );
+            return Err(ASABRError::ParsingError(CowError::new(
+                "The max node numbers for the contact and node definitions do not match",
+            )));
         }
         if nodes.is_empty() {
-            return Err("Nodes must be declared".to_string());
+            return Err(ASABRError::ParsingError(CowError::new(
+                "Nodes must be declared",
+            )));
         }
         if nodes.len() - 1 != max_node_id_in_nodes {
-            return Err("Some node declarations are missing".to_string());
+            return Err(ASABRError::ParsingError(CowError::new(
+                "Some node declarations are missing",
+            )));
         }
 
         ContactPlan::new(nodes, contacts, Some(VirtualNodeMap::new(vnode_map)))
-            .map_err(|_| "Failed to create contact plan".to_string())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cell::BorrowMutError;
 use std::error::Error;
 use std::fmt;
@@ -30,3 +31,29 @@ impl From<ASABRError> for std::io::Error {
         std::io::Error::other(err)
     }
 }
+
+#[derive(Debug)]
+pub struct CowError(Cow<'static, str>);
+
+impl CowError {
+    /// Borrows `'a str`s, clones and owns `String`s as needed.
+    ///
+    /// Usage:
+    ///
+    /// * No allocation for static messages:
+    ///   * `return Err(ASABRError::ParsingError(CowError::new("A static error message")));`
+    ///
+    /// * Allocates and owns a dynamically determined message:
+    ///   * `return Err(ASABRError::ParsingError(CowError::new(format!("A dynamic error: {context}"))));`
+    pub fn new(msg: impl Into<Cow<'static, str>>) -> Self {
+        Self(msg.into())
+    }
+}
+
+impl fmt::Display for CowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Error for CowError {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum ASABRError {
+    ParsingError(CowError),
     BorrowMutError(&'static str),
     DryRunError(&'static str),
     ScheduleError(&'static str),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use a_sabr::{
         segmentation::seg::SegmentationManager,
     },
     contact_plan::{asabr_file_lexer::FileLexer, from_asabr_lexer::ASABRContactPlan},
-    errors::ASABRError,
+    errors::{ASABRError, CowError},
     node_manager::none::NoManagement,
     parsing::{ContactMarkerMap, coerce_cm},
     route_storage::cache::TreeCache,
@@ -42,7 +42,12 @@ fn main() -> Result<(), ASABRError> {
         None,
         Some(&contact_dispatch),
     )
-    .unwrap();
+    .map_err(|e| match e {
+        ASABRError::ParsingError(e) => ASABRError::ParsingError(CowError::new(
+            format!("<cp_file> must be in ASABR format with NoManagement for nodes and dynamic management (evl, qd, eto or seg) for contacts. Error while parsing CP: {e}"),
+        )),
+        _ => e,
+    })?;
 
     // We create a storage for the Paths
     let table = Rc::new(RefCell::new(TreeCache::new(true, false, 10)));


### PR DESCRIPTION
This PR adds error handling, and a specific CP error for `src/main.rs`.

I also had fun implementing some optimized error handling with Cow, that makes a difference between `&'static str`, and `String` (such as `String` returned by `format!()`).

If it's interesting we could keep this new type. Makes the lib a tiny bit more efficient I guess. Then we could use it where useful.