### PR TITLE
First no std patch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 bin/
 /target
 .vscode
-/src/main.rs
 cp_examples
 /target/
 debug/

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@ This project is open to contributions, including documentation, testing, bug rep
 ## Acknowledgments
 - Nicolas Le Borgne - code contributions
 - Isaac Lluís - code reviews
+- Louwen Fricout - No-std port

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-derivative = "2.2.0"
+derivative = { version = "2.2.0", features = ["use_core"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/benches/spsn_benchmark.rs
+++ b/benches/spsn_benchmark.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+
 use a_sabr::{
     bundle::Bundle, contact_manager::segmentation::seg::SegmentationManager,
     contact_plan::from_tvgutil_file::TVGUtilContactPlan, node_manager::none::NoManagement,
@@ -75,9 +77,11 @@ pub fn benchmark(c: &mut Criterion) {
         group.bench_function(router_type, |b| {
             b.iter_batched(
                 || {
+                    let file = File::open(ptvg_filepath).unwrap();
+                    let json = serde_json::from_reader(file).unwrap();
                     let contact_plan =
                         TVGUtilContactPlan::parse::<NoManagement, SegmentationManager>(
-                            ptvg_filepath,
+                            json,
                         )
                         .unwrap();
 

--- a/benches/spsn_benchmark.rs
+++ b/benches/spsn_benchmark.rs
@@ -80,10 +80,8 @@ pub fn benchmark(c: &mut Criterion) {
                     let file = File::open(ptvg_filepath).unwrap();
                     let json = serde_json::from_reader(file).unwrap();
                     let contact_plan =
-                        TVGUtilContactPlan::parse::<NoManagement, SegmentationManager>(
-                            json,
-                        )
-                        .unwrap();
+                        TVGUtilContactPlan::parse::<NoManagement, SegmentationManager>(json)
+                            .unwrap();
 
                     match build_generic_router(router_type, contact_plan, Some(spsn_opts.clone())) {
                         Ok(rter) => rter,

--- a/examples/bundle_processing/bundle_processing.rs
+++ b/examples/bundle_processing/bundle_processing.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
 use a_sabr::bundle::Bundle;
 use a_sabr::contact_manager::legacy::evl::EVLManager;
 use a_sabr::distance::sabr::SABR;
@@ -13,7 +16,7 @@ use a_sabr::pathfinding::hybrid_parenting::HybridParentingPath;
 use a_sabr::types::Date;
 use a_sabr::types::Priority;
 use a_sabr::types::Token;
-use a_sabr::utils::{init_pathfinding, pretty_print};
+use a_sabr::utils::init_pathfinding;
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 struct Compressing {
@@ -92,12 +95,15 @@ fn edge_case_example<NM: NodeManager + Parser<NM> + DispatchParser<NM>>(
         size: 100.0,
         expiration: 1000.0,
     };
+    let file = File::open(cp_path).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
     let mut mpt_graph = init_pathfinding::<
         NM,
         EVLManager,
         HybridParentingPath<NM, EVLManager, SABR>,
-    >(cp_path, node_marker_map, None)?;
+        _,
+    >(lines.iter().map(|s| s.as_str()), node_marker_map, None)?;
 
     println!(
         "\nRunning with contact plan location={cp_path}, destination node=3, and bundle priority={bundle_priority}"
@@ -106,7 +112,7 @@ fn edge_case_example<NM: NodeManager + Parser<NM> + DispatchParser<NM>>(
     let res = mpt_graph.get_next(0.0, 0, &bundle, &[]).unwrap();
 
     match res.by_destination[3].clone() {
-        Some(route) => pretty_print(route),
+        Some(route) => print!("{}", route.borrow()),
         _ => println!("No route found to node 3."),
     }
 

--- a/examples/contact_plans/contact_plans.rs
+++ b/examples/contact_plans/contact_plans.rs
@@ -1,3 +1,8 @@
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
 use a_sabr::{
     contact_manager::{
         ContactManager,
@@ -18,8 +23,11 @@ use a_sabr::{
 
 fn main() {
     // ION, with contact segmentation
-    let contact_plan = IONContactPlan::parse::<NoManagement, SegmentationManager>(
-        "examples/contact_plans/ion_format.cp",
+    let file = File::open("examples/contact_plans/ion_format.cp").unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
+    let contact_plan = IONContactPlan::parse::<NoManagement, SegmentationManager, _>(
+        lines.iter().map(|s| s.as_str()),
     )
     .unwrap();
     println!(
@@ -28,8 +36,11 @@ fn main() {
         contact_plan.contacts.len()
     );
     // ION, with EVL
+    let file = File::open("examples/contact_plans/ion_format.cp").unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
     let contact_plan =
-        IONContactPlan::parse::<NoManagement, EVLManager>("examples/contact_plans/ion_format.cp")
+        IONContactPlan::parse::<NoManagement, EVLManager, _>(lines.iter().map(|s| s.as_str()))
             .unwrap();
     println!(
         "ION CP parsed, found {} nodes (no management) & {} contacts (EVL)",
@@ -38,8 +49,11 @@ fn main() {
     );
 
     // ION, with EVL + priorities
+    let file = File::open("examples/contact_plans/ion_format.cp").unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
     let contact_plan =
-        IONContactPlan::parse::<NoManagement, PEVLManager>("examples/contact_plans/ion_format.cp")
+        IONContactPlan::parse::<NoManagement, PEVLManager, _>(lines.iter().map(|s| s.as_str()))
             .unwrap();
     println!(
         "ION CP parsed, found {} nodes (no management) & {} contacts (EVL with priorities)",
@@ -48,10 +62,11 @@ fn main() {
     );
 
     // tvg-util, with contact segmentation
-    let contact_plan = TVGUtilContactPlan::parse::<NoManagement, SegmentationManager>(
-        "examples/contact_plans/tvgutil_format.cp",
-    )
-    .unwrap();
+    let file = File::open("examples/contact_plans/tvgutil_format.cp").unwrap();
+    let json: serde_json::Value = serde_json::from_reader(file).unwrap();
+
+    let contact_plan =
+        TVGUtilContactPlan::parse::<NoManagement, SegmentationManager>(json.clone()).unwrap();
     println!(
         "Tvg-util CP parsed, found {} nodes (no management) & {} contacts (segmentation)",
         contact_plan.vertices.len(),
@@ -59,10 +74,7 @@ fn main() {
     );
 
     // tvg-util, with EVL
-    let contact_plan = TVGUtilContactPlan::parse::<NoManagement, EVLManager>(
-        "examples/contact_plans/tvgutil_format.cp",
-    )
-    .unwrap();
+    let contact_plan = TVGUtilContactPlan::parse::<NoManagement, EVLManager>(json.clone()).unwrap();
     println!(
         "Tvg-util CP parsed, found {} nodes (no management) & {} contacts (EVL)",
         contact_plan.vertices.len(),
@@ -70,17 +82,16 @@ fn main() {
     );
 
     // tvg-util, with QD + priorities
-    let contact_plan = TVGUtilContactPlan::parse::<NoManagement, PQDManager>(
-        "examples/contact_plans/tvgutil_format.cp",
-    )
-    .unwrap();
+    let contact_plan = TVGUtilContactPlan::parse::<NoManagement, PQDManager>(json).unwrap();
     println!(
         "Tvg-util CP parsed, found {} nodes (no management) & {} contacts (queue-delay with priorities)",
         contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
+    let file = File::open("examples/contact_plans/asabr_format_static.cp").unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
-    let mut mylexer = FileLexer::new("examples/contact_plans/asabr_format_static.cp").unwrap();
+    let mut mylexer = FileLexer::new(lines.iter().map(|s| s.as_str()));
     let contact_plan =
         ASABRContactPlan::parse::<NoManagement, EVLManager>(&mut mylexer, None, None).unwrap();
     println!(
@@ -91,7 +102,10 @@ fn main() {
 
     // A new lexer must be initialized
     // The CP format is shared for all legacy contact managers, no CP modification required
-    let mut mylexer = FileLexer::new("examples/contact_plans/asabr_format_static.cp").unwrap();
+    let file = File::open("examples/contact_plans/asabr_format_static.cp").unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
+    let mut mylexer = FileLexer::new(lines.iter().map(|s| s.as_str()));
     let contact_plan =
         ASABRContactPlan::parse::<NoManagement, QDManager>(&mut mylexer, None, None).unwrap();
     println!(
@@ -99,8 +113,10 @@ fn main() {
         contact_plan.vertices.len(),
         contact_plan.contacts.len()
     );
+    let file = File::open("examples/contact_plans/asabr_format_dynamic.cp").unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
-    let mut mylexer = FileLexer::new("examples/contact_plans/asabr_format_dynamic.cp").unwrap();
+    let mut mylexer = FileLexer::new(lines.iter().map(|s| s.as_str()));
     // All nodes will have the same management approach (NoManagement) but the contacts may be of various types
     // We provide a map with markers that will allow the parser to create the correct contacts types thanks to
     // the markers provides in the contact plan

--- a/examples/dijkstra_accuracy/dijkstra_accuracy.rs
+++ b/examples/dijkstra_accuracy/dijkstra_accuracy.rs
@@ -1,3 +1,8 @@
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
 use a_sabr::{
     bundle::Bundle,
     contact_manager::legacy::evl::EVLManager,
@@ -8,7 +13,7 @@ use a_sabr::{
         Pathfinding, hybrid_parenting::HybridParentingPath, node_parenting::NodeParentingPath,
     },
     types::NodeID,
-    utils::{init_pathfinding, pretty_print},
+    utils::init_pathfinding,
 };
 
 #[cfg(feature = "contact_work_area")]
@@ -22,41 +27,63 @@ fn edge_case_example(cp_path: &str, dest: NodeID) -> Result<(), ASABRError> {
         size: 0.0,
         expiration: 1000.0,
     };
+    let file = File::open(cp_path).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
     let mut node_graph = init_pathfinding::<
         NoManagement,
         EVLManager,
         NodeParentingPath<NoManagement, EVLManager, SABR>,
-    >(cp_path, None, None)?;
+        _,
+    >(lines.iter().map(|s| s.as_str()), None, None)?;
 
     #[cfg(feature = "contact_work_area")]
-    let mut contact_graph = init_pathfinding::<
-        NoManagement,
-        EVLManager,
-        ContactParentingPath<NoManagement, EVLManager, SABR>,
-    >(cp_path, None, None)?;
+    let mut contact_graph = {
+        let file = File::open(cp_path).unwrap();
+        let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
+        init_pathfinding::<
+            NoManagement,
+            EVLManager,
+            ContactParentingPath<NoManagement, EVLManager, SABR>,
+            _,
+        >(lines.iter().map(|s| s.as_str()), None, None)?
+    };
+
+    let file = File::open(cp_path).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
     let mut mpt_graph = init_pathfinding::<
         NoManagement,
         EVLManager,
         HybridParentingPath<NoManagement, EVLManager, SABR>,
-    >(cp_path, None, None)?;
+        _,
+    >(lines.iter().map(|s| s.as_str()), None, None)?;
 
     println!("\nRunning with contact plan location={cp_path}, and destination node={dest} ");
     let res = node_graph.get_next(0.0, 0, &bundle, &[]).unwrap();
     print!("\nWith NodeParentingPath pathfinding. ");
-    pretty_print(res.by_destination[dest as usize].clone().unwrap());
+    println!(
+        "{}",
+        res.by_destination[dest as usize].clone().unwrap().borrow()
+    );
 
     #[cfg(feature = "contact_work_area")]
     {
         let res = contact_graph.get_next(0.0, 0, &bundle, &[]).unwrap();
         print!("With ContactParentingPath pathfinding. ");
-        pretty_print(res.by_destination[dest as usize].clone().unwrap());
+        println!(
+            "{}",
+            res.by_destination[dest as usize].clone().unwrap().borrow()
+        );
     }
 
     let res = mpt_graph.get_next(0.0, 0, &bundle, &[]).unwrap();
     print!("With HybridParentingPath pathfinding. ");
-    pretty_print(res.by_destination[dest as usize].clone().unwrap());
+    println!(
+        "{}",
+        res.by_destination[dest as usize].clone().unwrap().borrow()
+    );
 
     Ok(())
 }

--- a/examples/eto_management/eto_management.rs
+++ b/examples/eto_management/eto_management.rs
@@ -1,3 +1,7 @@
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+
 use a_sabr::bundle::Bundle;
 use a_sabr::contact_manager::ContactManager;
 use a_sabr::contact_manager::legacy::eto::ETOManager;
@@ -10,7 +14,6 @@ use a_sabr::parsing::ContactMarkerMap;
 use a_sabr::parsing::coerce_cm;
 use a_sabr::routing::aliases::SpsnOptions;
 use a_sabr::routing::aliases::build_generic_router;
-use a_sabr::utils::pretty_print;
 
 fn main() {
     #[cfg(not(feature = "manual_queueing"))]
@@ -23,7 +26,10 @@ fn main() {
     contact_dispatch.add("qd", coerce_cm::<QDManager>);
 
     // We create a lexer to retrieve tokens from a file
-    let mut mylexer = FileLexer::new("examples/eto_management/contact_plan_1.cp").unwrap();
+    let file = File::open("examples/eto_management/contact_plan_1.cp").unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
+    let mut mylexer = FileLexer::new(lines.iter().map(|s| s.as_str()));
 
     // We parse the contact plan (A-SABR format thanks to ASABRContactPlan) and the lexer
     let contact_plan = ASABRContactPlan::parse::<NoManagement, Box<dyn ContactManager>>(
@@ -62,8 +68,7 @@ fn main() {
     let (first_hop_contact, route) = out.lazy_get_for_unicast(3).unwrap();
 
     // Retain a ref to the first_hop manager
-
-    pretty_print(route);
+    println!("{}", route.borrow());
     // Enqueue the bundle_1
     #[cfg(feature = "manual_queueing")]
     println!(
@@ -89,7 +94,7 @@ fn main() {
         .unwrap()
         .unwrap();
     let (first_hop_contact, route) = out.lazy_get_for_unicast(3).unwrap();
-    pretty_print(route);
+    println!("{}", route.borrow());
 
     // Enqueue the bundle_2
     #[cfg(feature = "manual_queueing")]
@@ -137,7 +142,7 @@ fn main() {
         .unwrap()
         .unwrap();
     let (_, route) = out.lazy_get_for_unicast(4).unwrap();
-    pretty_print(route);
+    println!("{}", route.borrow());
 
     // === OUTPUT ===
     // Running with contact plan location=examples/dijkstra_accuracy/contact_plan_1.cp, and destination node=3

--- a/examples/inter-regional_routing/inter-regional_routing.rs
+++ b/examples/inter-regional_routing/inter-regional_routing.rs
@@ -1,4 +1,9 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::RefCell,
+    fs::File,
+    io::{BufRead, BufReader},
+    rc::Rc,
+};
 
 use a_sabr::{
     bundle::Bundle,
@@ -13,7 +18,6 @@ use a_sabr::{
     parsing::{ContactMarkerMap, coerce_cm},
     route_storage::cache::TreeCache,
     routing::{Router, aliases::SpsnHybridParenting},
-    utils::{pretty_print, pretty_print_multigraph},
 };
 
 fn main() {
@@ -29,7 +33,10 @@ fn main() {
 
     // The manager type should be Box<dyn ContactManager>> (heap allocated, dynamically dispatched)
     // Replace None with a dispatching map for the contact_marker_map argument
-    let mut mylexer = FileLexer::new(cp_path).unwrap();
+    let file = File::open(cp_path).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+
+    let mut mylexer = FileLexer::new(lines.iter().map(|s| s.as_str()));
     let contact_plan = ASABRContactPlan::parse::<NoManagement, Box<dyn ContactManager>>(
         &mut mylexer,
         None,
@@ -48,10 +55,12 @@ fn main() {
     println!("\n---\n");
 
     let graph = Multigraph::new(contact_plan).unwrap();
-    pretty_print_multigraph(&graph);
+    println!("{graph}");
 
     // Re-parse for the router, which consumes the contact plan to build its own multigraph.
-    let mut router_lexer = FileLexer::new(cp_path).unwrap();
+    let file = File::open(cp_path).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+    let mut router_lexer = FileLexer::new(lines.iter().map(|s| s.as_str()));
     let contact_plan = ASABRContactPlan::parse::<NoManagement, Box<dyn ContactManager>>(
         &mut router_lexer,
         None,
@@ -86,7 +95,7 @@ fn main() {
     if let Ok(Some(out)) = out {
         for (_contact, dest_routes) in out.first_hops.values() {
             for route_rc in dest_routes {
-                pretty_print(route_rc.clone());
+                println!("{}", route_rc.borrow());
             }
         }
     }

--- a/examples/satellite_constellation/satellite_constellation.rs
+++ b/examples/satellite_constellation/satellite_constellation.rs
@@ -1,3 +1,7 @@
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+
 use a_sabr::bundle::Bundle;
 use a_sabr::contact_manager::legacy::evl::EVLManager;
 use a_sabr::distance::sabr::SABR;
@@ -12,7 +16,7 @@ use a_sabr::pathfinding::hybrid_parenting::HybridParentingPath;
 use a_sabr::types::Date;
 use a_sabr::types::Duration;
 use a_sabr::types::Token;
-use a_sabr::utils::{init_pathfinding, pretty_print};
+use a_sabr::utils::init_pathfinding;
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 struct NoRetention {
@@ -81,19 +85,22 @@ fn edge_case_example<NM: NodeManager + Parser<NM> + DispatchParser<NM>>(
         size: 0.0,
         expiration: 1000.0,
     };
+    let file = File::open(cp_path).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
 
     let mut mpt_graph = init_pathfinding::<
         NM,
         EVLManager,
         HybridParentingPath<NM, EVLManager, SABR>,
-    >(cp_path, node_marker_map, None)?;
+        _,
+    >(lines.iter().map(|s| s.as_str()), node_marker_map, None)?;
 
     println!("\nRunning with contact plan location={cp_path}, and destination node=2 ");
 
     let res = mpt_graph.get_next(0.0, 0, &bundle, &[]).unwrap();
 
     match res.by_destination[2].clone() {
-        Some(route) => pretty_print(route),
+        Some(route) => println!("{}", route.borrow()),
         _ => println!("No route found to node 2."),
     }
 

--- a/exercises/2-contact-segmentation/2-contact-segmentation.rs
+++ b/exercises/2-contact-segmentation/2-contact-segmentation.rs
@@ -1,3 +1,5 @@
+use std::{fs::File, io::{BufRead, BufReader}};
+
 use a_sabr::{
     contact_manager::segmentation::seg::SegmentationManager,
     contact_plan::{asabr_file_lexer::FileLexer, from_asabr_lexer::ASABRContactPlan},
@@ -10,15 +12,10 @@ fn main() {
     // The cp is however incomplete, go check it out
 
     let cp_1 = "exercises/2-contact-segmentation/contact_plan.asabr";
-
-    let mylexer_res = FileLexer::new(cp_1);
-    let mut my_lexer = match mylexer_res {
-        Ok(val) => val,
-        Err(err) => {
-            println!("{err}");
-            return;
-        }
-    };
+    let file = File::open(cp_1).unwrap();
+    let iter: Vec<_> = BufReader::new(file).lines().map(|s| s.unwrap()).collect();
+    
+    let mut my_lexer = FileLexer::new(iter.iter().map(|s| s.as_str()));
 
     let contact_plan = match ASABRContactPlan::parse::<NoManagement, SegmentationManager>(
         &mut my_lexer,

--- a/exercises/2-contact-segmentation/2-contact-segmentation.rs
+++ b/exercises/2-contact-segmentation/2-contact-segmentation.rs
@@ -1,4 +1,7 @@
-use std::{fs::File, io::{BufRead, BufReader}};
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
 
 use a_sabr::{
     contact_manager::segmentation::seg::SegmentationManager,
@@ -14,7 +17,7 @@ fn main() {
     let cp_1 = "exercises/2-contact-segmentation/contact_plan.asabr";
     let file = File::open(cp_1).unwrap();
     let iter: Vec<_> = BufReader::new(file).lines().map(|s| s.unwrap()).collect();
-    
+
     let mut my_lexer = FileLexer::new(iter.iter().map(|s| s.as_str()));
 
     let contact_plan = match ASABRContactPlan::parse::<NoManagement, SegmentationManager>(

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,5 +1,6 @@
 use crate::types::{Date, NodeID, Priority, Volume};
-
+extern crate alloc;
+use alloc::vec::Vec;
 /// A structure representing a routing bundle containing essential information for pathfinding.
 ///
 /// The `Bundle` struct encapsulates the routing details required for determining optimal paths

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -5,10 +5,13 @@ use crate::parsing::{Lexer, Parser};
 #[cfg(feature = "contact_work_area")]
 use crate::route_stage::SharedRouteStage;
 use crate::types::{Date, NodeID, Token};
-use std::cell::RefCell;
-use std::cmp::Ordering;
-use std::marker::PhantomData;
-use std::rc::Rc;
+
+
+use core::cell::RefCell;
+use core::cmp::Ordering;
+use core::marker::PhantomData;
+extern crate alloc;
+use alloc::rc::Rc;
 
 /// Represents basic information about a contact between two nodes.
 #[derive(Clone, Copy)]

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -6,7 +6,6 @@ use crate::parsing::{Lexer, Parser};
 use crate::route_stage::SharedRouteStage;
 use crate::types::{Date, NodeID, Token};
 
-
 use core::cell::RefCell;
 use core::cmp::Ordering;
 use core::marker::PhantomData;

--- a/src/contact_manager/legacy/test_helpers.rs
+++ b/src/contact_manager/legacy/test_helpers.rs
@@ -11,6 +11,10 @@ pub(crate) const BUDGET_P0: Volume = 2000.0;
 pub(crate) const BUDGET_P1: Volume = 5000.0;
 pub(crate) const BUDGET_P2: Volume = TOTAL_VOL;
 
+extern crate alloc;
+
+use alloc::vec;
+
 pub(crate) fn make_contact_info(start: Date, end: Date) -> ContactInfo {
     ContactInfo::new(0, 1, start, end)
 }

--- a/src/contact_manager/mod.rs
+++ b/src/contact_manager/mod.rs
@@ -5,6 +5,9 @@ use crate::{bundle::Bundle, contact::ContactInfo, types::Date};
 pub mod legacy;
 pub mod segmentation;
 
+extern crate alloc;
+use alloc::boxed::Box;
+
 /// Data structure representing the transmission (tx) start, end, and related timing information.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ContactManagerTxData {
@@ -200,7 +203,7 @@ macro_rules! define_contact_manager {
 }
 
 #[cfg(feature = "debug")]
-define_contact_manager!(std::fmt::Debug);
+define_contact_manager!(core::fmt::Debug);
 
 #[cfg(not(feature = "debug"))]
 define_contact_manager!();

--- a/src/contact_manager/segmentation/mod.rs
+++ b/src/contact_manager/segmentation/mod.rs
@@ -1,3 +1,7 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 use crate::contact::ContactInfo;
 use crate::errors::ASABRError;
 use crate::parsing::{Lexer, LexerOutput};
@@ -249,7 +253,7 @@ pub trait BaseSegmentationManager {
 /// Returns a `Result<LexerOutput<T>, ASABRError>`:
 /// - `Finished((start, end, val))` if the interval is successfully parsed.
 /// - An error from Date::parse(), or if an unexpected end-of-file is encountered during parsing.
-fn parse_interval<T: std::str::FromStr>(
+fn parse_interval<T: core::str::FromStr>(
     lexer: &mut dyn Lexer,
 ) -> Result<(Date, Date, T), ASABRError> {
     let start: Date = Date::parse(lexer)?;

--- a/src/contact_manager/segmentation/pseg.rs
+++ b/src/contact_manager/segmentation/pseg.rs
@@ -12,6 +12,14 @@ use crate::{
     types::{DataRate, Date, Duration, Priority},
 };
 
+extern crate alloc;
+
+// used as macro and not module. poor detection
+#[allow(unused_imports)]
+use alloc::vec;
+
+use alloc::vec::Vec;
+
 /// Priority-aware segmentation manager. Tracks bandwidth availability per priority level
 /// using booking intervals.
 #[cfg_attr(feature = "debug", derive(Debug))]

--- a/src/contact_manager/segmentation/seg.rs
+++ b/src/contact_manager/segmentation/seg.rs
@@ -12,6 +12,10 @@ use crate::{
     types::{DataRate, Date, Duration},
 };
 
+extern crate alloc;
+// used as macro and not module. poor detection
+#[allow(unused_imports)]
+use alloc::{vec, vec::Vec};
 /// Manages contact segments, where each segment may have a distinct data rate and delay.
 ///
 /// The `SegmentationManager` uses different segments to manage free intervals, rate intervals, and delay intervals,

--- a/src/contact_plan/asabr_file_lexer.rs
+++ b/src/contact_plan/asabr_file_lexer.rs
@@ -59,7 +59,7 @@ impl<'a, T: Iterator<Item = &'a str>> FileLexer<'a, T> {
     ///
     /// Returns an `io::Result<()>` indicating success or failure in reading the next line.
     fn read_next_line(&mut self) {
-        while let Some(line) = self.reader.next() {
+        for line in self.reader.by_ref() {
             self.lookup_current_line += 1;
 
             // Skip lines starting with '#'

--- a/src/contact_plan/asabr_file_lexer.rs
+++ b/src/contact_plan/asabr_file_lexer.rs
@@ -1,6 +1,7 @@
-use std::{
-    fs::File,
-    io::{self, BufRead, BufReader},
+extern crate alloc;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
 };
 
 use crate::{
@@ -12,20 +13,20 @@ use crate::{
 ///
 /// The `FileLexer` reads a file line by line, processes tokens (words), and provides them one at a time for parsing.
 /// It skips lines starting with `#`, allowing them to be used as comments in the input file.
-pub struct FileLexer {
+pub struct FileLexer<'a, T: Iterator<Item = &'a str>> {
     /// Tracks the current line number during lookup operations.
-    lookup_current_line: u32,
+    lookup_current_line: usize,
     /// Tracks the line number from which the current token was consumed.
-    current_line: u32,
+    current_line: usize,
     /// Tracks the token's position in the current line.
-    token_position: u32,
+    token_position: usize,
     /// A buffered reader for the input file.
-    reader: BufReader<File>,
+    reader: T,
     /// A stack that stores tokens (words) from the file, in reverse order, for easy consumption.
-    buffer_stack: Vec<String>,
+    buffer_stack: Vec<&'a str>,
 }
 
-impl FileLexer {
+impl<'a, T: Iterator<Item = &'a str>> FileLexer<'a, T> {
     /// Creates a new `FileLexer` for the specified file.
     ///
     /// # Arguments
@@ -39,16 +40,14 @@ impl FileLexer {
     /// # Errors
     ///
     /// Will return an `io::Error` if the file cannot be opened.
-    pub fn new(filename: &str) -> io::Result<Self> {
-        let file = File::open(filename)?;
-        let reader = BufReader::new(file);
-        Ok(Self {
+    pub fn new(content: T) -> Self {
+        Self {
             lookup_current_line: 0,
             current_line: 0,
             token_position: 0,
-            reader,
+            reader: content,
             buffer_stack: Vec::new(),
-        })
+        }
     }
 
     /// Reads the next line of the file and splits it into words, storing them in the buffer stack.
@@ -59,15 +58,8 @@ impl FileLexer {
     /// # Returns
     ///
     /// Returns an `io::Result<()>` indicating success or failure in reading the next line.
-    fn read_next_words(&mut self) -> io::Result<()> {
-        loop {
-            let mut line = String::new();
-            let bytes_read = self.reader.read_line(&mut line)?;
-
-            if bytes_read == 0 {
-                return Ok(());
-            }
-
+    fn read_next_line(&mut self) {
+        while let Some(line) = self.reader.next() {
             self.lookup_current_line += 1;
 
             // Skip lines starting with '#'
@@ -76,18 +68,16 @@ impl FileLexer {
             }
 
             // Split the line into words and collect them into a vector in reverse order
-            let words: Vec<String> = line.split_whitespace().rev().map(String::from).collect();
-            if words.is_empty() {
-                continue;
+            let words: Vec<_> = line.split_whitespace().rev().collect();
+            if !words.is_empty() {
+                self.buffer_stack.extend(words);
+                return;
             }
-
-            self.buffer_stack.extend(words);
-            return Ok(());
         }
     }
 }
 
-impl Lexer for FileLexer {
+impl<'a, T: Iterator<Item = &'a str>> Lexer for FileLexer<'a, T> {
     /// Consumes and returns the next token (word) from the file.
     ///
     /// If the buffer is empty, it reads the next line of words into the buffer before consuming a token.
@@ -98,8 +88,7 @@ impl Lexer for FileLexer {
     /// `Ok(LexerOutput::EOF)` if the end of the file is reached, or `Err` if an error occurs.
     fn consume_next_token(&mut self) -> Result<LexerOutput<String>, ASABRError> {
         if self.buffer_stack.is_empty() {
-            self.read_next_words()
-                .map_err(|e| ASABRError::ParsingError(e.to_string()))?;
+            self.read_next_line();
         }
 
         let next_word = self.buffer_stack.pop();
@@ -110,7 +99,7 @@ impl Lexer for FileLexer {
                     self.current_line = self.lookup_current_line;
                 }
                 self.token_position += 1;
-                Ok(LexerOutput::Finished(word))
+                Ok(LexerOutput::Finished(word.to_string()))
             }
             None => Ok(LexerOutput::EOF),
         }
@@ -123,8 +112,8 @@ impl Lexer for FileLexer {
     /// # Returns
     ///
     /// A string in the format `"line {current_line}, token {token_position}"`.
-    fn get_current_position(&self) -> String {
-        format!("line {}, token {}", self.current_line, self.token_position)
+    fn get_current_position(&self) -> (usize, usize) {
+        (self.current_line, self.token_position)
     }
 
     /// Looks at the next token without consuming it.
@@ -137,8 +126,7 @@ impl Lexer for FileLexer {
     /// `Ok(LexerOutput::EOF)` if the end of the file is reached, or `Err` if an error occurs.
     fn lookup(&mut self) -> Result<LexerOutput<String>, ASABRError> {
         if self.buffer_stack.is_empty() {
-            self.read_next_words()
-                .map_err(|e| ASABRError::ParsingError(e.to_string()))?;
+            self.read_next_line();
         }
 
         let next_word = self.buffer_stack.last();

--- a/src/contact_plan/from_asabr_lexer.rs
+++ b/src/contact_plan/from_asabr_lexer.rs
@@ -13,7 +13,12 @@ use crate::{
     node_manager::NodeManager,
     parsing::{DispatchParser, Lexer, LexerOutput, parse_components},
 };
-use std::collections::{HashMap, HashSet};
+extern crate alloc;
+use alloc::{
+    collections::{BTreeMap as HashMap, BTreeSet as HashSet},
+    string::String,
+    vec::Vec,
+};
 
 enum RealNodeType {
     Node,
@@ -61,7 +66,8 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
     fn check_real_id(&self, id: NodeID) -> Result<(), ASABRError> {
         if (id as usize) >= self.real_nodes_count() {
             return Err(ASABRError::ParsingError(
-                "Contact tx/rx ids or virtual node rids must match an already declared real node id".to_string(),
+                "Contact tx/rx ids or virtual node rids must match an already declared real node id. ID,node_count:",
+                (id.into(), self.real_nodes_count()),
             ));
         }
         Ok(())
@@ -70,7 +76,8 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
     fn check_new_real_id(&self, id: NodeID) -> Result<(), ASABRError> {
         if (id as usize) != self.real_nodes_count() {
             return Err(ASABRError::ParsingError(
-                "Declare real nodes before virtual nodes, in increasing id order".to_string(),
+                "Declare real nodes before virtual nodes, in increasing id order. ID,node_count:",
+                (id.into(), self.real_nodes_count()),
             ));
         }
         Ok(())
@@ -79,7 +86,8 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
     fn check_new_virtual_id(&self, id: NodeID) -> Result<(), ASABRError> {
         if (id as usize) != self.vertices.len() {
             return Err(ASABRError::ParsingError(
-                "Declare virtual nodes after the real nodes, in increasing id order".to_string(),
+                "Declare virtual nodes after the real nodes, in increasing id order. ID,vertice_count:",
+                (id.into(), self.vertices.len()),
             ));
         }
         Ok(())
@@ -90,10 +98,10 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
             if let Vertex::ENode(enode) = vertex
                 && !self.rid_to_vnodes_map.contains_key(&enode.info.id)
             {
-                return Err(ASABRError::ParsingError(format!(
-                    "ENode '{}' (id: {}) is not labeled by any vnode",
-                    enode.info.name, enode.info.id,
-                )));
+                return Err(ASABRError::ParsingError(
+                    "an ENode is not labeled by any vnode. Id:",
+                    (enode.info.id.into(), 0),
+                ));
             }
         }
         Ok(())
@@ -104,7 +112,8 @@ impl<NM: NodeManager, CM: ContactManager> Builder<NM, CM> {
     fn register_name(&mut self, name: String) -> Result<(), ASABRError> {
         if !self.node_names.insert(name) {
             return Err(ASABRError::ParsingError(
-                "Another vertex shares this name".to_string(),
+                "Another vertex shares this name",
+                (0, 0),
             ));
         }
         Ok(())
@@ -163,10 +172,10 @@ impl ASABRContactPlan {
     ) -> Result<Node<NM>, ASABRError> {
         let (info, manager) = parse_components::<NodeInfo, NM>(lexer, *node_marker_map)?;
         let Some(node) = Node::try_new(info, manager) else {
-            return Err(ASABRError::ParsingError(format!(
+            return Err(ASABRError::ParsingError(
                 "Malformed node ({})",
-                lexer.get_current_position()
-            )));
+                lexer.get_current_position(),
+            ));
         };
         Ok(node)
     }
@@ -192,10 +201,10 @@ impl ASABRContactPlan {
                     let (info, manager) =
                         parse_components::<ContactInfo, CM>(lexer, contact_marker_map)?;
                     let Some(contact) = Contact::try_new(info, manager) else {
-                        return Err(ASABRError::ParsingError(format!(
+                        return Err(ASABRError::ParsingError(
                             "Malformed contact ({})",
-                            lexer.get_current_position()
-                        )));
+                            lexer.get_current_position(),
+                        ));
                     };
                     builder.add_contact(contact)?;
                 }
@@ -217,10 +226,10 @@ impl ASABRContactPlan {
                     builder.add_virtual_node(info)?;
                 }
                 _ => {
-                    return Err(ASABRError::ParsingError(format!(
+                    return Err(ASABRError::ParsingError(
                         "Unrecognized CP element ({})",
-                        lexer.get_current_position()
-                    )));
+                        lexer.get_current_position(),
+                    ));
                 }
             }
         }

--- a/src/contact_plan/from_ion_file.rs
+++ b/src/contact_plan/from_ion_file.rs
@@ -17,11 +17,10 @@ use crate::{
     vertex::Vertex,
 };
 
-use std::{cmp::Ordering, collections::HashMap};
-use std::{
-    fs::File,
-    io::{self, BufRead, BufReader},
-};
+extern crate alloc;
+use alloc::{collections::BTreeMap as HashMap, string::ToString, vec, vec::Vec};
+
+use core::cmp::Ordering;
 
 pub struct IONContactData {
     tx_start: Date,
@@ -111,16 +110,16 @@ impl FromIONContactData<NoManagement, SegmentationManager> for SegmentationManag
 
 pub struct IONContactPlan {}
 
-fn manage_aliases(
-    map_id_map: &mut HashMap<String, NodeID>,
-    candidate_name: &String,
+fn manage_aliases<'a>(
+    map_id_map: &mut HashMap<&'a str, NodeID>,
+    candidate_name: &'a str,
     vertices: &mut Vec<Vertex<NoManagement>>,
 ) -> NodeID {
     if let Some(value) = map_id_map.get(candidate_name) {
         *value
     } else {
         let next = map_id_map.len() as NodeID;
-        map_id_map.insert(candidate_name.clone(), next);
+        map_id_map.insert(candidate_name, next);
         vertices.push(Vertex::INode(
             Node::try_new(
                 NodeInfo {
@@ -155,7 +154,7 @@ fn manage_contacts(
     }
 }
 
-fn get_confidence(vec: &[String]) -> f32 {
+fn get_confidence(vec: &[&str]) -> f32 {
     if vec.len() >= 8 {
         vec[7].parse::<f32>().unwrap()
     } else {
@@ -164,12 +163,16 @@ fn get_confidence(vec: &[String]) -> f32 {
 }
 
 impl IONContactPlan {
-    pub fn parse<NM: NodeManager, CM: FromIONContactData<NM, CM> + ContactManager>(
-        filename: &str,
-    ) -> io::Result<ContactPlan<NoManagement, CM>> {
-        let file = File::open(filename)?;
-        let mut reader = BufReader::new(file);
-        let mut map_id_map: HashMap<String, NodeID> = HashMap::new();
+    pub fn parse<
+        'a,
+        NM: NodeManager,
+        CM: FromIONContactData<NM, CM> + ContactManager,
+        T: Iterator<Item = &'a str>,
+    >(
+        content: T,
+    ) -> Result<ContactPlan<NoManagement, CM>, ASABRError> {
+        let mut reader = content;
+        let mut map_id_map = HashMap::new();
 
         let mut ranges = vec![];
         let mut contact_info_map: HashMap<NodeID, HashMap<NodeID, Vec<IONContactData>>> =
@@ -179,33 +182,28 @@ impl IONContactPlan {
         let mut contacts = vec![];
         let mut vertices = vec![];
 
-        loop {
-            let mut line = String::new();
-            let bytes_read = reader.read_line(&mut line)?;
-
-            if bytes_read == 0 {
-                break;
-            }
+        while let Some(line) = reader.next() {
             // Skip lines starting with '#'
             if line.trim_start().starts_with('#') {
                 continue;
             }
-            let words: Vec<String> = line.split_whitespace().map(String::from).collect();
+            let words: Vec<_> = line.split_whitespace().collect();
 
             if words.is_empty() {
                 continue;
             }
 
-            if words[0].as_str() != "a" {
+            if words[0] != "a" {
                 continue;
             }
-            if words[1].as_str() == "contact" {
+
+            if words[1] == "contact" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
                 let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut vertices);
                 let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut vertices);
                 let data_rate: DataRate = words[6].parse().unwrap();
-                let confidence = get_confidence(&words);
+                let confidence = get_confidence(words.as_slice());
                 contact_count += 1;
 
                 manage_contacts(
@@ -221,7 +219,7 @@ impl IONContactPlan {
                     },
                 );
             }
-            if words[1].as_str() == "range" {
+            if words[1] == "range" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
                 let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut vertices);
@@ -235,7 +233,6 @@ impl IONContactPlan {
                     delay,
                 });
             }
-            continue;
         }
 
         for map in contact_info_map.values_mut() {
@@ -255,7 +252,7 @@ impl IONContactPlan {
                     } else {
                         return Err(ASABRError::ContactPlanError(
                             "This parser only supports one range per contact",
-                        ))?;
+                        ));
                     }
                 }
             }
@@ -264,9 +261,9 @@ impl IONContactPlan {
         if contacts.len() != contact_count {
             return Err(ASABRError::ContactPlanError(
                 "At least one contact has no range",
-            ))?;
+            ));
         }
 
-        Ok(ContactPlan::new(vertices, contacts, None)?)
+        ContactPlan::new(vertices, contacts, None)
     }
 }

--- a/src/contact_plan/from_ion_file.rs
+++ b/src/contact_plan/from_ion_file.rs
@@ -171,7 +171,7 @@ impl IONContactPlan {
     >(
         content: T,
     ) -> Result<ContactPlan<NoManagement, CM>, ASABRError> {
-        let mut reader = content;
+        let reader = content;
         let mut map_id_map = HashMap::new();
 
         let mut ranges = vec![];
@@ -182,7 +182,7 @@ impl IONContactPlan {
         let mut contacts = vec![];
         let mut vertices = vec![];
 
-        while let Some(line) = reader.next() {
+        for line in reader {
             // Skip lines starting with '#'
             if line.trim_start().starts_with('#') {
                 continue;
@@ -200,8 +200,8 @@ impl IONContactPlan {
             if words[1] == "contact" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
-                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut vertices);
-                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut vertices);
+                let tx_node_id = manage_aliases(&mut map_id_map, words[4], &mut vertices);
+                let rx_node_id = manage_aliases(&mut map_id_map, words[5], &mut vertices);
                 let data_rate: DataRate = words[6].parse().unwrap();
                 let confidence = get_confidence(words.as_slice());
                 contact_count += 1;
@@ -222,8 +222,8 @@ impl IONContactPlan {
             if words[1] == "range" {
                 let tx_start: Date = words[2].parse().unwrap();
                 let tx_end: Date = words[3].parse().unwrap();
-                let tx_node_id = manage_aliases(&mut map_id_map, &words[4], &mut vertices);
-                let rx_node_id = manage_aliases(&mut map_id_map, &words[5], &mut vertices);
+                let tx_node_id = manage_aliases(&mut map_id_map, words[4], &mut vertices);
+                let rx_node_id = manage_aliases(&mut map_id_map, words[5], &mut vertices);
                 let delay: Duration = words[6].parse().unwrap();
                 ranges.push(IONRangeData {
                     tx_start,

--- a/src/contact_plan/from_tvgutil_file.rs
+++ b/src/contact_plan/from_tvgutil_file.rs
@@ -146,6 +146,6 @@ impl TVGUtilContactPlan {
                 contacts.push(contact);
             }
         }
-        Ok(ContactPlan::new(vertices, contacts, None)?)
+        ContactPlan::new(vertices, contacts, None)
     }
 }

--- a/src/contact_plan/from_tvgutil_file.rs
+++ b/src/contact_plan/from_tvgutil_file.rs
@@ -10,16 +10,17 @@ use crate::{
         segmentation::{Segment, seg::SegmentationManager},
     },
     contact_plan::ContactPlan,
+    errors::ASABRError,
     node::{Node, NodeInfo},
     node_manager::{NodeManager, none::NoManagement},
     types::{DataRate, Date, Duration, NodeID},
     vertex::Vertex,
 };
 
-use std::{collections::HashMap, io};
+extern crate alloc;
+use alloc::{collections::BTreeMap as HashMap, string::ToString, vec, vec::Vec};
 
 use serde_json::Value;
-use std::fs;
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct TVGUtilContactData {
@@ -82,16 +83,17 @@ pub struct TVGUtilContactPlan {}
 
 impl TVGUtilContactPlan {
     pub fn parse<NM: NodeManager, CM: FromTVGUtilContactData<NM, CM> + ContactManager>(
-        filename: &str,
-    ) -> io::Result<ContactPlan<NoManagement, CM>> {
+        json_data: serde_json::Value,
+    ) -> Result<ContactPlan<NoManagement, CM>, ASABRError> {
         let mut vertices: Vec<Vertex<NoManagement>> = Vec::new();
         let mut contacts: Vec<Contact<NoManagement, CM>> = Vec::new();
 
         let mut map_id_map: HashMap<&str, NodeID> = HashMap::new();
 
-        let json_data = fs::read_to_string(filename)?;
-        let parsed: Value = serde_json::from_str(&json_data).unwrap();
-        let json_nodes = parsed["vertices"].as_object().unwrap();
+        let parsed: Value = json_data;
+        let json_nodes = parsed["vertices"]
+            .as_object()
+            .ok_or(ASABRError::ContactPlanError("no \"vertice\" in json"))?;
 
         for (node_id, (node_name, _node_data)) in json_nodes.iter().enumerate() {
             map_id_map.insert(node_name, node_id as NodeID);
@@ -108,7 +110,9 @@ impl TVGUtilContactPlan {
             ));
         }
 
-        let json_contacts = parsed["edges"].as_array().unwrap();
+        let json_contacts = parsed["edges"]
+            .as_array()
+            .ok_or(ASABRError::ContactPlanError("no \"edge\" in json"))?;
         for nodes_pair in json_contacts {
             let data = nodes_pair.as_object().unwrap();
             let pair = data["vertices"].as_array().unwrap();

--- a/src/contact_plan/mod.rs
+++ b/src/contact_plan/mod.rs
@@ -1,3 +1,6 @@
+extern crate alloc;
+use alloc::vec::Vec;
+
 use crate::contact::Contact;
 use crate::contact_manager::ContactManager;
 use crate::errors::ASABRError;

--- a/src/distance/hop.rs
+++ b/src/distance/hop.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use crate::{
     contact_manager::ContactManager, node_manager::NodeManager,

--- a/src/distance/mod.rs
+++ b/src/distance/mod.rs
@@ -1,5 +1,9 @@
-use std::cmp::Ordering;
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+extern crate alloc;
+
+use alloc::rc::Rc;
+
+use core::cmp::Ordering;
+use core::{cell::RefCell, marker::PhantomData};
 
 use crate::node_manager::NodeManager;
 use crate::{contact_manager::ContactManager, route_stage::RouteStage};
@@ -64,7 +68,7 @@ impl<NM: NodeManager, CM: ContactManager, D: Distance<NM, CM>> DistanceWrapper<N
 }
 
 impl<NM: NodeManager, CM: ContactManager, D: Distance<NM, CM>> Ord for DistanceWrapper<NM, CM, D> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         D::cmp(&self.0.borrow(), &other.0.borrow())
     }
 }
@@ -72,7 +76,7 @@ impl<NM: NodeManager, CM: ContactManager, D: Distance<NM, CM>> Ord for DistanceW
 impl<NM: NodeManager, CM: ContactManager, D: Distance<NM, CM>> PartialOrd
     for DistanceWrapper<NM, CM, D>
 {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/src/distance/sabr.rs
+++ b/src/distance/sabr.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use crate::{
     contact_manager::ContactManager, node_manager::NodeManager,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
-use std::cell::{BorrowError, BorrowMutError};
-use std::error::Error;
-use std::fmt;
+use core::cell::{BorrowError, BorrowMutError};
+use core::error::Error;
+use core::fmt;
 
 #[derive(Debug)]
 pub enum ASABRError {
@@ -9,7 +9,7 @@ pub enum ASABRError {
     ScheduleError(&'static str),
     ContactPlanError(&'static str),
     MulticastUnsupportedError,
-    ParsingError(String),
+    ParsingError(&'static str, (usize, usize)),
 }
 
 impl From<BorrowError> for ASABRError {
@@ -26,14 +26,26 @@ impl From<BorrowMutError> for ASABRError {
 
 impl fmt::Display for ASABRError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
+        match *self {
+            ASABRError::BorrowMutError(s) => write!(f, "BorrowMutError in A-SABR: {}", s),
+            ASABRError::DryRunError(s) => write!(f, "DryRunError in A-SABR: {}", s),
+            ASABRError::ScheduleError(s) => write!(f, "ScheduleError in A-SABR: {}", s),
+            ASABRError::ContactPlanError(s) => write!(f, "ContactPlanError in A-SABR: {}", s),
+            ASABRError::MulticastUnsupportedError => {
+                write!(f, "Multicast is Unsupported in A-SABR")
+            }
+            ASABRError::ParsingError(s, l) => write!(
+                f,
+                "Parsing Error encountered at line {} tocken {} in A-SABR: {}",
+                l.0, l.1, s
+            ),
+        }
     }
 }
 
 impl Error for ASABRError {}
 
-impl From<ASABRError> for std::io::Error {
-    fn from(err: ASABRError) -> Self {
-        std::io::Error::other(err)
-    }
-}
+//     fn from(err: ASABRError) -> Self {
+//         std::io::Error::other(err)
+//     }
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// Module containing the adaptive contact definition.
 pub mod contact;
 /// Module containing the variable component of a contact for resource management.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+use std::alloc::System;
+
+#[global_allocator]
+static GLOBAL: System = System;
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::{cell::RefCell, env, rc::Rc};
 
 use a_sabr::{
@@ -13,7 +20,6 @@ use a_sabr::{
     parsing::{ContactMarkerMap, coerce_cm},
     route_storage::cache::TreeCache,
     routing::{Router, aliases::SpsnHybridParenting},
-    utils::pretty_print,
 };
 
 fn main() -> Result<(), ASABRError> {
@@ -25,7 +31,9 @@ fn main() -> Result<(), ASABRError> {
     println!("Working with cp {}.", args[1]);
 
     // We create a lexer to retrieve tokens from a file
-    let mut mylexer = FileLexer::new(&args[1]).unwrap();
+    let file = File::open(&args[1]).unwrap();
+    let lines: Vec<String> = BufReader::new(file).lines().map(|l| l.unwrap()).collect();
+    let mut mylexer = FileLexer::new(lines.iter().map(|s| s.as_str()));
 
     // All nodes will have the same management approach (NoManagement) but the contacts may be of various types
     // We provide a map with markers that will allow the parser to create the correct contacts types thanks to
@@ -43,9 +51,12 @@ fn main() -> Result<(), ASABRError> {
         Some(&contact_dispatch),
     )
     .map_err(|e| match e {
-        ASABRError::ParsingError(e) => ASABRError::ParsingError(
-            format!("<cp_file> must be in ASABR format with NoManagement for nodes and dynamic management (evl, qd, eto or seg) for contacts. Error while parsing CP: {e}"),
-        ),
+        ASABRError::ParsingError(e,pos) => {
+            eprintln!("Parsing error: {e}");
+            ASABRError::ParsingError(
+            "<cp_file> must be in ASABR format with NoManagement for nodes and dynamic management (evl, qd, eto or seg) for contacts. Error while parsing CP",
+                    pos
+        )},
         _ => e,
     })?;
 
@@ -73,7 +84,7 @@ fn main() -> Result<(), ASABRError> {
     if let Ok(Some(out)) = out {
         for (_contact, dest_routes) in out.first_hops.values() {
             for route_rc in dest_routes {
-                pretty_print(route_rc.clone());
+                println!("{}", route_rc.borrow());
             }
         }
     }

--- a/src/multigraph.rs
+++ b/src/multigraph.rs
@@ -1,6 +1,8 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
+extern crate alloc;
+
+use alloc::{collections::BTreeMap as HashMap, rc::Rc, vec, vec::Vec};
+use core::cell::RefCell;
+use core::fmt::Display;
 
 use super::node::Node;
 use crate::contact::Contact;
@@ -121,13 +123,13 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
         let vertex_count = contact_plan.vertices.len();
         let virtual_node_count = contact_plan.vnode_map.get_vnode_to_rids_map().len();
         let real_node_count = vertex_count - virtual_node_count;
-        let mut virtual_nodes = Vec::new();
+        let mut virtual_nodes = Vec::with_capacity(virtual_node_count);
         #[allow(clippy::type_complexity)]
         // Maps contacts to Sender vertex IDs and Receiver vertex IDs.
         let mut snd_rcv_map: HashMap<
             VertexID,
             HashMap<VertexID, Vec<Rc<RefCell<Contact<NM, CM>>>>>,
-        > = HashMap::with_capacity(vertex_count);
+        > = HashMap::new();
         let mut is_external = vec![false; vertex_count];
 
         // output
@@ -174,13 +176,13 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
                 .get(&real_tx_id)
                 .into_iter()
                 .flatten()
-                .chain(std::iter::once(&real_tx_id))
+                .chain(core::iter::once(&real_tx_id))
             {
                 for r in vnodes_for_rid
                     .get(&real_rx_id)
                     .into_iter()
                     .flatten()
-                    .chain(std::iter::once(&real_rx_id))
+                    .chain(core::iter::once(&real_rx_id))
                 {
                     // Only add inodes and vnodes as Sender/Receiver in the graph
                     // AND if the Sender/Receiver IDs are different.
@@ -261,5 +263,49 @@ impl<NM: NodeManager, CM: ContactManager> Multigraph<NM, CM> {
     /// * `usize` - The total number of vertices.
     pub fn get_vertex_count(&self) -> usize {
         self.vertex_count
+    }
+}
+
+impl<NM: NodeManager, CM: ContactManager> Display for Multigraph<NM, CM> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let real_node_count = self.real_nodes.len();
+        let label =
+            |f: &mut core::fmt::Formatter, vid: crate::vertex::VertexID| -> core::fmt::Result {
+                if (vid as usize) < real_node_count {
+                    let node = self.real_nodes[vid as usize].borrow();
+                    write!(f, "node {} \"{}\"", node.info.id, node.info.name)?
+                } else {
+                    write!(f, "vnode {vid}")?
+                }
+                Ok(())
+            };
+
+        writeln!(
+            f,
+            "Multigraph: {} vertices ({} real node(s), {} vnode(s))",
+            self.get_vertex_count(),
+            real_node_count,
+            self.get_vertex_count() - real_node_count,
+        )?;
+
+        for sender in &self.senders {
+            write!(f, "- Sender ")?;
+            label(f, sender.vertex_id)?;
+            writeln!(f, ":")?;
+            for receiver in &sender.receivers {
+                write!(f, "    -> Receiver ")?;
+                label(f, receiver.vertex_id)?;
+                writeln!(f, " ({} contact(s)):", receiver.contacts_to_receiver.len(),)?;
+                for contact_rc in &receiver.contacts_to_receiver {
+                    let c = contact_rc.borrow();
+                    writeln!(
+                        f,
+                        "        * tx={} rx={} [{}, {}]",
+                        c.info.tx_node_id, c.info.rx_node_id, c.info.start, c.info.end,
+                    )?;
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,6 @@
-use std::{cell::RefCell, cmp::Ordering, rc::Rc};
+extern crate alloc;
+use alloc::rc::Rc;
+use core::{cell::RefCell, cmp::Ordering};
 
 use crate::{
     errors::ASABRError,

--- a/src/node_manager/mod.rs
+++ b/src/node_manager/mod.rs
@@ -1,6 +1,9 @@
+extern crate alloc;
+
+use alloc::boxed::Box;
+
 #[cfg(any(feature = "node_proc", feature = "node_tx", feature = "node_rx"))]
 use crate::{bundle::Bundle, types::Date};
-
 pub mod none;
 
 macro_rules! define_node_manager {
@@ -187,7 +190,7 @@ macro_rules! define_node_manager {
 }
 
 #[cfg(feature = "debug")]
-define_node_manager!(std::fmt::Debug);
+define_node_manager!(core::fmt::Debug);
 
 #[cfg(not(feature = "debug"))]
 define_node_manager!();

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, str::FromStr};
+extern crate alloc;
+
+use core::str::FromStr;
+
+use alloc::{boxed::Box, collections::btree_map::BTreeMap as HashMap, string::String, vec::Vec};
 
 use crate::{contact_manager::ContactManager, errors::ASABRError, node_manager::NodeManager};
 
@@ -32,20 +36,20 @@ impl<T: FromStr> Parser<Vec<T>> for Vec<T> {
             let token = match lexer.consume_next_token()? {
                 LexerOutput::Finished(t) => t,
                 LexerOutput::EOF => {
-                    return Err(ASABRError::ParsingError(format!(
-                        "Parsing failed, expected ']' ({})",
-                        lexer.get_current_position()
-                    )));
+                    return Err(ASABRError::ParsingError(
+                        "Parsing failed, expected ']'",
+                        lexer.get_current_position(),
+                    ));
                 }
             };
             let token = token.trim();
 
             if !started {
                 if !token.starts_with('[') {
-                    return Err(ASABRError::ParsingError(format!(
-                        "Parsing failed, expected '[' ({})",
-                        lexer.get_current_position()
-                    )));
+                    return Err(ASABRError::ParsingError(
+                        "Parsing failed, expected '['",
+                        lexer.get_current_position(),
+                    ));
                 }
                 started = true;
             }
@@ -59,10 +63,10 @@ impl<T: FromStr> Parser<Vec<T>> for Vec<T> {
             };
 
             if !try_push(inner, &mut items) {
-                return Err(ASABRError::ParsingError(format!(
-                    "Parsing failed ({})",
-                    lexer.get_current_position()
-                )));
+                return Err(ASABRError::ParsingError(
+                    "Parsing failed",
+                    lexer.get_current_position(),
+                ));
             }
 
             if closes {
@@ -135,7 +139,7 @@ pub trait Lexer {
     /// Consumes and returns the next token from the input stream.
     fn consume_next_token(&mut self) -> Result<LexerOutput<String>, ASABRError>;
     /// Returns the current position in the input stream.
-    fn get_current_position(&self) -> String;
+    fn get_current_position(&self) -> (usize, usize);
 }
 
 /// Trait for parsing a generic type `T` from a lexer.
@@ -157,9 +161,10 @@ macro_rules! implement_parser {
     ($manager_type:ident) => {
         /// Dispatching is impossible for concrete Parser types.
         impl Parser<Box<dyn $manager_type>> for Box<dyn $manager_type> {
-            fn parse(_lexer: &mut dyn Lexer) -> Result<Box<dyn $manager_type>, ASABRError> {
+            fn parse(lexer: &mut dyn Lexer) -> Result<Box<dyn $manager_type>, ASABRError> {
                 Err(ASABRError::ParsingError(
-                    "Unable to dispatch to the correct parser, the Dispatcher".to_string(),
+                    "Unable to dispatch to the correct parser, the Dispatcher",
+                    lexer.get_current_position()
                 ))
             }
         }
@@ -258,26 +263,26 @@ macro_rules! implement_manager {
             ) -> Result<Box<dyn $manager_type>, ASABRError> {
                 let marker = match lexer.consume_next_token()? {
                     LexerOutput::EOF => {
-                        return Err(ASABRError::ParsingError(format!(
-                            "Marker expected ({})",
-                            lexer.get_current_position()
-                        )));
+                        return Err(ASABRError::ParsingError(
+                            "Marker expected",
+                            lexer.get_current_position(),
+                        ));
                     }
                     LexerOutput::Finished(marker) => marker,
                 };
 
                 let Some(marker_map) = marker_map_opt else {
-                    return Err(ASABRError::ParsingError(format!(
-                        "Dynamic parsing requires a map ({})",
-                        lexer.get_current_position()
-                    )));
+                    return Err(ASABRError::ParsingError(
+                        "Dynamic parsing requires a map",
+                        lexer.get_current_position(),
+                    ));
                 };
 
                 let Some(parse_fn) = marker_map.get(marker.as_str()) else {
-                    return Err(ASABRError::ParsingError(format!(
-                        "Unrecognized marker ({})",
-                        lexer.get_current_position()
-                    )));
+                    return Err(ASABRError::ParsingError(
+                        "Unrecognized marker",
+                        lexer.get_current_position(),
+                    ));
                 };
 
                 parse_fn(lexer)

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -164,7 +164,7 @@ macro_rules! implement_parser {
             fn parse(lexer: &mut dyn Lexer) -> Result<Box<dyn $manager_type>, ASABRError> {
                 Err(ASABRError::ParsingError(
                     "Unable to dispatch to the correct parser, the Dispatcher",
-                    lexer.get_current_position()
+                    lexer.get_current_position(),
                 ))
             }
         }

--- a/src/pathfinding/contact_parenting.rs
+++ b/src/pathfinding/contact_parenting.rs
@@ -1,7 +1,10 @@
 extern crate alloc;
-use alloc::{collections::BinaryHeap,rc::Rc,vec::Vec,vec};
-use core::{cell::RefCell, cmp::{Ordering,Reverse}, marker::PhantomData};
-
+use alloc::{collections::BinaryHeap, rc::Rc, vec, vec::Vec};
+use core::{
+    cell::RefCell,
+    cmp::{Ordering, Reverse},
+    marker::PhantomData,
+};
 
 use crate::{
     bundle::Bundle,

--- a/src/pathfinding/contact_parenting.rs
+++ b/src/pathfinding/contact_parenting.rs
@@ -1,10 +1,7 @@
-use std::{
-    cell::RefCell,
-    cmp::{Ordering, Reverse},
-    collections::BinaryHeap,
-    marker::PhantomData,
-    rc::Rc,
-};
+extern crate alloc;
+use alloc::{collections::BinaryHeap,rc::Rc,vec::Vec,vec};
+use core::{cell::RefCell, cmp::{Ordering,Reverse}, marker::PhantomData};
+
 
 use crate::{
     bundle::Bundle,

--- a/src/pathfinding/hybrid_parenting.rs
+++ b/src/pathfinding/hybrid_parenting.rs
@@ -1,5 +1,5 @@
 extern crate alloc;
-use alloc::{collections::BinaryHeap, rc::Rc, vec, vec::Vec,borrow::ToOwned};
+use alloc::{borrow::ToOwned, collections::BinaryHeap, rc::Rc, vec, vec::Vec};
 
 use core::{
     cell::RefCell,

--- a/src/pathfinding/hybrid_parenting.rs
+++ b/src/pathfinding/hybrid_parenting.rs
@@ -1,9 +1,10 @@
-use std::{
+extern crate alloc;
+use alloc::{collections::BinaryHeap, rc::Rc, vec, vec::Vec,borrow::ToOwned};
+
+use core::{
     cell::RefCell,
     cmp::{Ordering, Reverse},
-    collections::BinaryHeap,
     marker::PhantomData,
-    rc::Rc,
 };
 
 use crate::{

--- a/src/pathfinding/limiting_contact/first_depleted.rs
+++ b/src/pathfinding/limiting_contact/first_depleted.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 use crate::{
     contact::Contact, contact_manager::ContactManager, create_new_alternative_path_variant,
     node_manager::NodeManager,

--- a/src/pathfinding/limiting_contact/first_ending.rs
+++ b/src/pathfinding/limiting_contact/first_ending.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 use crate::{
     contact::Contact, contact_manager::ContactManager, create_new_alternative_path_variant,
     node_manager::NodeManager,

--- a/src/pathfinding/limiting_contact/mod.rs
+++ b/src/pathfinding/limiting_contact/mod.rs
@@ -2,8 +2,10 @@ use crate::contact::Contact;
 use crate::contact_manager::ContactManager;
 use crate::node_manager::NodeManager;
 use crate::route_stage::SharedRouteStage;
-use std::cell::RefCell;
-use std::rc::Rc;
+use core::cell::RefCell;
+
+extern crate alloc;
+use alloc::rc::Rc;
 
 #[cfg(feature = "first_depleted")]
 pub mod first_depleted;
@@ -102,12 +104,12 @@ macro_rules! create_new_alternative_path_variant {
         > {
             /// The underlying pathfinding algorithm used to find individual paths.
             pathfinding: P,
-            suppression_map: Vec<Vec<std::rc::Rc<std::cell::RefCell<Contact<NM, CM>>>>>,
+            suppression_map: alloc::vec::Vec<alloc::vec::Vec<alloc::rc::Rc<core::cell::RefCell<Contact<NM, CM>>>>>,
 
             #[doc(hidden)]
-            _phantom_nm: std::marker::PhantomData<NM>,
+            _phantom_nm: core::marker::PhantomData<NM>,
             #[doc(hidden)]
-            _phantom_cm: std::marker::PhantomData<CM>,
+            _phantom_cm: core::marker::PhantomData<CM>,
         }
 
         impl<
@@ -128,15 +130,15 @@ macro_rules! create_new_alternative_path_variant {
             ///
             #[doc = concat!("* `Self` - A new instance of `", stringify!($struct_name), "`.")]
             fn new(
-                multigraph: std::rc::Rc<std::cell::RefCell<$crate::multigraph::Multigraph<NM, CM>>>
+                multigraph: alloc::rc::Rc<core::cell::RefCell<$crate::multigraph::Multigraph<NM, CM>>>
             ) -> Self {
                 let node_count = multigraph.borrow().get_vertex_count();
                 Self {
 
                     pathfinding: P::new(multigraph),
-                    suppression_map: vec![Vec::new(); node_count],
-                    _phantom_nm: std::marker::PhantomData,
-                    _phantom_cm: std::marker::PhantomData,
+                    suppression_map: alloc::vec![alloc::vec::Vec::new(); node_count],
+                    _phantom_nm: core::marker::PhantomData,
+                    _phantom_cm: core::marker::PhantomData,
                 }
             }
             /// Finds the next route based on the current state and available contacts.
@@ -198,7 +200,7 @@ macro_rules! create_new_alternative_path_variant {
             /// # Returns
             ///
             /// * A shared pointer to the multigraph.
-            fn get_multigraph(&self) -> std::rc::Rc<std::cell::RefCell<$crate::multigraph::Multigraph<NM, CM>>> {
+            fn get_multigraph(&self) -> alloc::rc::Rc<core::cell::RefCell<$crate::multigraph::Multigraph<NM, CM>>> {
                 return self.pathfinding.get_multigraph();
             }
         }

--- a/src/pathfinding/mod.rs
+++ b/src/pathfinding/mod.rs
@@ -1,3 +1,7 @@
+extern crate alloc;
+use alloc::{rc::Rc, vec, vec::Vec};
+use core::cell::RefCell;
+
 use crate::bundle::Bundle;
 use crate::contact::Contact;
 use crate::contact_manager::{ContactManager, ContactManagerTxData};
@@ -9,8 +13,6 @@ use crate::route_stage::ViaHop;
 use crate::route_stage::{RouteStage, SharedRouteStage};
 use crate::types::{Date, NodeID};
 use crate::vertex::VertexID;
-use std::cell::RefCell;
-use std::rc::Rc;
 
 #[cfg(feature = "contact_work_area")]
 pub mod contact_parenting;
@@ -279,8 +281,6 @@ mod tests {
     use crate::pathfinding::test_helpers::*;
     use crate::route_stage::RouteStage;
     use crate::vertex::VertexID;
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     #[track_caller]
     fn run_hop<NM: NodeManager>(

--- a/src/pathfinding/node_parenting.rs
+++ b/src/pathfinding/node_parenting.rs
@@ -1,7 +1,6 @@
-use std::{
-    cell::RefCell, cmp::Ordering, cmp::Reverse, collections::BinaryHeap, marker::PhantomData,
-    rc::Rc,
-};
+extern crate alloc;
+use alloc::{collections::BinaryHeap, rc::Rc};
+use core::{cell::RefCell, cmp::Ordering, cmp::Reverse, marker::PhantomData};
 
 use crate::{
     bundle::Bundle,

--- a/src/pathfinding/test_helpers.rs
+++ b/src/pathfinding/test_helpers.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 use crate::bundle::Bundle;
 use crate::contact::Contact;
 use crate::contact::ContactInfo;
@@ -15,9 +17,11 @@ use crate::route_stage::{RouteStage, SharedRouteStage};
 use crate::types::Date;
 use crate::vertex::Vertex;
 use crate::vnode::VirtualNodeMap;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
+use alloc::collections::BTreeMap as HashMap;
+use alloc::rc::Rc;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cell::RefCell;
 
 #[derive(Debug)]
 pub(crate) struct MockNodeManager {

--- a/src/route_stage.rs
+++ b/src/route_stage.rs
@@ -1,3 +1,7 @@
+extern crate alloc;
+
+use alloc::{collections::BTreeMap as HashMap, rc::Rc, vec::Vec};
+
 use crate::bundle::Bundle;
 use crate::contact::Contact;
 use crate::contact_manager::ContactManager;
@@ -6,9 +10,8 @@ use crate::node::Node;
 use crate::node_manager::NodeManager;
 use crate::types::{Date, Duration, HopCount, NodeID};
 use crate::vertex::VertexID;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
+use core::cell::RefCell;
+use core::fmt::Display;
 
 /// Represents an intermediate hop in a route, typically used for multi-hop communication or routing.
 ///
@@ -333,5 +336,44 @@ impl<NM: NodeManager, CM: ContactManager> RouteStage<NM, CM> {
             return Some(via.contact.clone());
         }
         None
+    }
+}
+
+impl<NM: NodeManager, CM: ContactManager> Display for RouteStage<NM, CM> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut backtrace = Vec::new();
+        writeln!(
+            f,
+            "Route to node {} at t={} with {} hop(s): ",
+            self.to_node, self.at_time, self.hop_count
+        )?;
+        // let mut curr_route_opt = Some(self);
+        // while let Some(curr_route_rc) = curr_route_opt.take() {
+        //     let curr_route = curr_route_rc;
+        //     backtrace.push((curr_route.to_node, curr_route.at_time, curr_route.hop_count));
+        //     match &curr_route.via {
+        //         Some(via_val) => curr_route_opt = Some(&*via_val.parent_route.clone().try_borrow().unwrap()),
+        //         None => curr_route_opt = None,
+        //     }
+        // }
+        //
+        fn back<CM: ContactManager, NM: NodeManager>(
+            backtrace: &mut Vec<(u16, f64, u16)>,
+            route: &RouteStage<NM, CM>,
+        ) {
+            backtrace.push((route.to_node, route.at_time, route.hop_count));
+            if let Some(via) = &route.via {
+                back(backtrace, &*via.parent_route.borrow());
+            }
+        }
+        back(&mut backtrace, self);
+        for data in backtrace.iter().rev() {
+            writeln!(
+                f,
+                "\t- Reach node {} at t={} with {} hop(s)",
+                data.0, data.1, data.2
+            )?;
+        }
+        Ok(())
     }
 }

--- a/src/route_storage/cache.rs
+++ b/src/route_storage/cache.rs
@@ -1,4 +1,7 @@
-use std::{cell::RefCell, collections::VecDeque, marker::PhantomData, rc::Rc};
+extern crate alloc;
+use alloc::{collections::VecDeque, rc::Rc, vec::Vec};
+
+use core::{cell::RefCell, marker::PhantomData};
 
 use crate::{
     bundle::Bundle,

--- a/src/route_storage/mod.rs
+++ b/src/route_storage/mod.rs
@@ -1,4 +1,7 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+extern crate alloc;
+use alloc::{collections::BTreeMap as HashMap, rc::Rc, vec::Vec};
+
+use core::cell::RefCell;
 
 pub mod cache;
 pub mod table;

--- a/src/route_storage/table.rs
+++ b/src/route_storage/table.rs
@@ -1,4 +1,8 @@
-use std::{cell::RefCell, cmp::Ordering, marker::PhantomData, rc::Rc};
+extern crate alloc;
+
+use alloc::{rc::Rc, vec, vec::Vec};
+
+use core::{cell::RefCell, cmp::Ordering, marker::PhantomData};
 
 use crate::{
     bundle::Bundle, contact_manager::ContactManager, distance::Distance, errors::ASABRError,

--- a/src/routing/aliases.rs
+++ b/src/routing/aliases.rs
@@ -13,7 +13,7 @@ use crate::{
     route_storage::{cache::TreeCache, table::RoutingTable},
     routing::volcgr::VolCgr,
 };
-use alloc::{rc::Rc,boxed::Box};
+use alloc::{boxed::Box, rc::Rc};
 use core::cell::RefCell;
 
 #[cfg(feature = "contact_suppression")]

--- a/src/routing/aliases.rs
+++ b/src/routing/aliases.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 use crate::{
     contact_manager::ContactManager,
     contact_plan::ContactPlan,
@@ -11,7 +13,8 @@ use crate::{
     route_storage::{cache::TreeCache, table::RoutingTable},
     routing::volcgr::VolCgr,
 };
-use std::{cell::RefCell, rc::Rc};
+use alloc::{rc::Rc,boxed::Box};
+use core::cell::RefCell;
 
 #[cfg(feature = "contact_suppression")]
 use super::cgr::Cgr;

--- a/src/routing/cgr.rs
+++ b/src/routing/cgr.rs
@@ -10,8 +10,10 @@ use crate::{
     route_storage::{Route, RouteStorage},
     types::{Date, NodeID},
 };
+extern crate alloc;
 
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+use alloc::rc::Rc;
+use core::{cell::RefCell, marker::PhantomData};
 
 use super::{Router, RoutingOutput, dry_run_unicast_path, schedule_unicast_path};
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
-use core::{cell::RefCell};
-use alloc::{collections::BTreeMap as HashMap, rc::Rc, vec::Vec, vec};
+use alloc::{collections::BTreeMap as HashMap, rc::Rc, vec, vec::Vec};
+use core::cell::RefCell;
 
 use crate::{
     bundle::Bundle,

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,4 +1,6 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+extern crate alloc;
+use core::{cell::RefCell};
+use alloc::{collections::BTreeMap as HashMap, rc::Rc, vec::Vec, vec};
 
 use crate::{
     bundle::Bundle,

--- a/src/routing/spsn.rs
+++ b/src/routing/spsn.rs
@@ -10,7 +10,9 @@ use crate::{
     types::{Date, NodeID},
 };
 
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+extern crate alloc;
+use core::{cell::RefCell, marker::PhantomData};
+use alloc::rc::Rc;
 
 use super::{Router, RoutingOutput, schedule_multicast, schedule_unicast};
 

--- a/src/routing/spsn.rs
+++ b/src/routing/spsn.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 
 extern crate alloc;
-use core::{cell::RefCell, marker::PhantomData};
 use alloc::rc::Rc;
+use core::{cell::RefCell, marker::PhantomData};
 
 use super::{Router, RoutingOutput, schedule_multicast, schedule_unicast};
 

--- a/src/routing/volcgr.rs
+++ b/src/routing/volcgr.rs
@@ -10,8 +10,9 @@ use crate::{
     route_storage::{Route, RouteStorage},
     types::{Date, NodeID},
 };
-
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+extern crate alloc;
+use alloc::rc::Rc;
+use core::{cell::RefCell, marker::PhantomData};
 
 use super::{Router, RoutingOutput, dry_run_unicast_path, schedule_unicast_path};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, str::FromStr};
+extern crate alloc;
+
+use alloc::{vec::Vec, string::String, collections::BTreeMap as HashMap};
+use core::str::FromStr;
 
 use crate::{
     errors::ASABRError,
@@ -20,7 +23,7 @@ pub type NodeName = String;
 /// Represents a duration in units (e.g., seconds).
 pub type Duration = f64;
 
-/// Represents a date (could represent days since a specific epoch).
+/// Represents a date (could represent days since a specific epoch).lo
 pub type Date = Duration;
 
 /// Represents the priority of a task or node.
@@ -58,19 +61,19 @@ impl<T: FromStr> Token<T> for T {
     fn parse(lexer: &mut dyn Lexer) -> Result<T, ASABRError> {
         let token = match lexer.consume_next_token()? {
             LexerOutput::EOF => {
-                return Err(ASABRError::ParsingError(format!(
-                    "Expected token, found EOF ({})",
+                return Err(ASABRError::ParsingError(
+                    "Expected token, found EOF",
                     lexer.get_current_position()
-                )));
+                ));
             }
             LexerOutput::Finished(token) => token,
         };
         match token.parse::<T>() {
             Ok(value) => Ok(value),
-            Err(_) => Err(ASABRError::ParsingError(format!(
+            Err(_) => Err(ASABRError::ParsingError(
                 "Parsing failed ({})",
                 lexer.get_current_position()
-            ))),
+            )),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use alloc::{vec::Vec, string::String, collections::BTreeMap as HashMap};
+use alloc::{collections::BTreeMap as HashMap, string::String, vec::Vec};
 use core::str::FromStr;
 
 use crate::{
@@ -63,7 +63,7 @@ impl<T: FromStr> Token<T> for T {
             LexerOutput::EOF => {
                 return Err(ASABRError::ParsingError(
                     "Expected token, found EOF",
-                    lexer.get_current_position()
+                    lexer.get_current_position(),
                 ));
             }
             LexerOutput::Finished(token) => token,
@@ -72,7 +72,7 @@ impl<T: FromStr> Token<T> for T {
             Ok(value) => Ok(value),
             Err(_) => Err(ASABRError::ParsingError(
                 "Parsing failed ({})",
-                lexer.get_current_position()
+                lexer.get_current_position(),
             )),
         }
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,6 @@
-use std::{cell::RefCell, rc::Rc};
+extern crate alloc;
+use alloc::rc::Rc;
+use core::cell::RefCell;
 
 use crate::{
     contact_manager::ContactManager,
@@ -8,19 +10,20 @@ use crate::{
     node_manager::NodeManager,
     parsing::{DispatchParser, Parser, StaticMarkerMap},
     pathfinding::Pathfinding,
-    route_stage::SharedRouteStage,
 };
 
 pub fn init_pathfinding<
+    'a,
     NM: NodeManager + DispatchParser<NM> + Parser<NM>,
     CM: ContactManager + DispatchParser<CM> + Parser<CM>,
     P: Pathfinding<NM, CM>,
+    T: Iterator<Item = &'a str>,
 >(
-    cp_path: &str,
+    content: T,
     node_marker_map: Option<&StaticMarkerMap<NM>>,
     contact_marker_map: Option<&StaticMarkerMap<CM>>,
 ) -> Result<P, ASABRError> {
-    let mut mylexer = FileLexer::new(cp_path).unwrap();
+    let mut mylexer = FileLexer::new(content);
     let nodes_n_contacts =
         ASABRContactPlan::parse::<NM, CM>(&mut mylexer, node_marker_map, contact_marker_map)
             .unwrap();
@@ -28,67 +31,4 @@ pub fn init_pathfinding<
     Ok(P::new(Rc::new(RefCell::new(Multigraph::new(
         nodes_n_contacts,
     )?))))
-}
-
-pub fn pretty_print_multigraph<NM: NodeManager, CM: ContactManager>(graph: &Multigraph<NM, CM>) {
-    let real_node_count = graph.real_nodes.len();
-    let label = |vid: crate::vertex::VertexID| -> String {
-        if (vid as usize) < real_node_count {
-            let node = graph.real_nodes[vid as usize].borrow();
-            format!("node {} \"{}\"", node.info.id, node.info.name)
-        } else {
-            format!("vnode {vid}")
-        }
-    };
-
-    println!(
-        "Multigraph: {} vertices ({} real node(s), {} vnode(s))",
-        graph.get_vertex_count(),
-        real_node_count,
-        graph.get_vertex_count() - real_node_count,
-    );
-
-    for sender in &graph.senders {
-        println!("- Sender {}:", label(sender.vertex_id));
-        for receiver in &sender.receivers {
-            println!(
-                "    -> Receiver {} ({} contact(s)):",
-                label(receiver.vertex_id),
-                receiver.contacts_to_receiver.len(),
-            );
-            for contact_rc in &receiver.contacts_to_receiver {
-                let c = contact_rc.borrow();
-                println!(
-                    "        * tx={} rx={} [{}, {}]",
-                    c.info.tx_node_id, c.info.rx_node_id, c.info.start, c.info.end,
-                );
-            }
-        }
-    }
-}
-
-pub fn pretty_print<NM: NodeManager, CM: ContactManager>(route: SharedRouteStage<NM, CM>) {
-    let mut backtrace: Vec<String> = Vec::new();
-    println!(
-        "Route to node {} at t={} with {} hop(s): ",
-        route.borrow().to_node,
-        route.borrow().at_time,
-        route.borrow().hop_count
-    );
-    let mut curr_route_opt = Some(route);
-    while let Some(curr_route_rc) = curr_route_opt.take() {
-        let curr_route = curr_route_rc.borrow();
-        backtrace.push(format!(
-            "\t- Reach node {} at t={} with {} hop(s)",
-            curr_route.to_node, curr_route.at_time, curr_route.hop_count
-        ));
-        match &curr_route.via {
-            Some(via_val) => curr_route_opt = Some(via_val.parent_route.clone()),
-            None => curr_route_opt = None,
-        }
-    }
-    println!(
-        "{}",
-        backtrace.into_iter().rev().collect::<Vec<_>>().join("\n")
-    );
 }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -1,3 +1,6 @@
+extern crate alloc;
+use alloc::string::String;
+
 use crate::{node::Node, node_manager::NodeManager, types::NodeID};
 
 /// Represents the unique inner identifier of a Vertex in the Multigraph.

--- a/src/vnode.rs
+++ b/src/vnode.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+extern crate alloc;
+
+use alloc::{collections::BTreeMap as HashMap, vec::Vec};
 
 use crate::{
     errors::ASABRError,
@@ -40,10 +42,10 @@ impl Parser<VirtualNodeInfo> for VirtualNodeInfo {
         for i in 0..rids.len() {
             for j in (i + 1)..rids.len() {
                 if rids[i] == rids[j] {
-                    return Err(ASABRError::ParsingError(format!(
-                        "Parsing failed: duplicate node ID in vnode definition ({})",
-                        lexer.get_current_position()
-                    )));
+                    return Err(ASABRError::ParsingError(
+                        "Parsing failed: duplicate node ID in vnode definition",
+                        lexer.get_current_position(),
+                    ));
                 }
             }
         }


### PR DESCRIPTION
Performance seems OK, need a proper bench to confirm no impact.
This is the first step toward microcontroller support, memory optimization is next.

This PR include two little public interface change:
- utils::pretty_print functions where removed in favor of implementing Display on the corresponding types.
- all parsing function take an Iterator<&str> (there is a plan to make that a bit more forgiving like a Iterator<AsRef<str>>) instead of a file path, allowing other sources than the file system, while putting the (small) burden of opening/converting to the proper format on the caller.

As the above needed patching of main, tests and benchmarks, main.rs was included back in the git (removed from .gitignore and updated).
This can be reverted if needed.


This PR change a lot of files, however this is mostly small patch in imports, and bring nearly no logic change, except for every HashMap being replaced by BTreeMap. As these are used mostly during parsing, the potential performance cost was judged negligible.